### PR TITLE
Updated from main code-base, changes include:

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,16 @@
 Revision history for cPanel-PublicAPI
 
+1.1	8/26/2015
+	Updated from main code-base, changes include:
+		Fixed non-numeric comparison errors.
+		Cleaned up uninitialized variable use.
+		Error checking after api_request in cPanel::PublicAPI::whm_api() call.
+		Correct comments in copyright headers w/ modified bsd license
+		Correct disclaimer in 3-clause BSD license
+		Changes to accommodate latest version of  IO::Socket::SSL
+		Removed Frontpage references
+		Changed to work with self-signed SSL certificates
+
 1.0     2/24/2011
         First version, Implement HTTP querying.
 

--- a/README
+++ b/README
@@ -50,7 +50,7 @@ You can also look for information at:
 
 LICENSE AND COPYRIGHT
 
-Copyright (c) 2011, cPanel, Inc.
+Copyright (c) 2015, cPanel, Inc.
 All rights reserved.
 http://cpanel.net
 

--- a/lib/cPanel/PublicAPI.pm
+++ b/lib/cPanel/PublicAPI.pm
@@ -1,32 +1,35 @@
 package cPanel::PublicAPI;
 
-# Copyright (c) 2011, cPanel, Inc.
+# Copyright (c) 2015, cPanel, Inc.
 # All rights reserved.
 # http://cpanel.net
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-#    * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#     * Neither the name of cPanel, Inc. nor the
-#       names of its contributors may be used to endorse or promote products
-#       derived from this software without specific prior written permission.
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the owner nor the names of its contributors may be
+# used to endorse or promote products derived from this software without
+# specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL  BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-our $VERSION = 1.001;
+our $VERSION = 1.1;
 
 use strict;
 use Socket           ();
@@ -99,12 +102,12 @@ sub new {
         $self->debug("Using user param from object creation") if $self->{'debug'};
     }
     else {
-        $self->{'user'} = exists $INC{'cPanel/PwCache.pm'} ? ( cPanel::PwCache::getpwuid($>) )[0] : ( getpwuid($>) )[0];
+        $self->{'user'} = exists $INC{'Cpanel/PwCache.pm'} ? ( Cpanel::PwCache::getpwuid($>) )[0] : ( getpwuid($>) )[0];
         $self->debug("Setting user based on current uid ($>)") if $self->{'debug'};
     }
 
     if ( ( !exists( $OPTS{'pass'} ) || $OPTS{'pass'} eq '' ) && ( !exists $OPTS{'accesshash'} || $OPTS{'accesshash'} eq '' ) ) {
-        my $homedir = exists $INC{'cPanel/PwCache.pm'} ? ( cPanel::PwCache::getpwuid($>) )[7] : ( getpwuid($>) )[7];
+        my $homedir = exists $INC{'Cpanel/PwCache.pm'} ? ( Cpanel::PwCache::getpwuid($>) )[7] : ( getpwuid($>) )[7];
         $self->debug("Attempting to detect correct authentication credentials") if $self->{'debug'};
 
         if ( -e $homedir . '/.accesshash' ) {
@@ -183,7 +186,9 @@ sub whm_api {
     my $uri = "/$query_format-api/$call";
 
     my ( $status, $statusmsg, $data ) = $self->api_request( 'whostmgr', $uri, 'POST', $formdata );
-
+    if ( $self->{'error'} ) {
+        die $self->{'error'};
+    }
     if ( defined $format && ( $format eq 'json' || $format eq 'xml' ) ) {
         return $$data;
     }
@@ -195,9 +200,9 @@ sub whm_api {
             die $self->{'error'};
         }
         if (
-            ( exists $parsed_data->{'error'} && $parsed_data->{'error'} =~ /Unknown App Requested/ ) ||                              # xml-api v0 version
+            ( exists $parsed_data->{'error'} && $parsed_data->{'error'} =~ /Unknown App Requested/ ) ||    # xml-api v0 version
             ( exists $parsed_data->{'metadata'}->{'reason'} && $parsed_data->{'metadata'}->{'reason'} =~ /Unknown app requested/ )
-          ) {                                                                                                                        # xml-api v1 version
+          ) {                                                                                              # xml-api v1 version
             $self->error("cPanel::PublicAPI::whm_api was called with the invalid API call of: $call.");
             return;
         }
@@ -251,6 +256,7 @@ sub api_request {
             IO::Socket::SSL->import('inet4');    # see case 16674
             $loaded_ssl = 1;
         }
+        IO::Socket::SSL->import('inet4');        # see case 16674
         $port = $service =~ /^\d+$/ ? $service : $PORT_DB{$service}{'ssl'};
     }
     else {
@@ -262,13 +268,13 @@ sub api_request {
     eval {
         if ( !$self->{'user'} ) {
             $self->error("You must specify a user to login as.");
-            die $self->{'error'};    #exit eval
+            die $self->{'error'};                #exit eval
         }
         my $remote_server = $self->{'ip'}   || $self->{'host'};
         my $server_name   = $self->{'host'} || $self->{'ip'};
         if ( !$remote_server ) {
-            $self->error("You must set a host to connect to.");
-            die $self->{'error'};    #exit eval
+            $self->error("You must set a host to connect to. (missing 'host' and 'ip' parameter)");
+            die $self->{'error'};                #exit eval
         }
         $server_name =~ s/\s*//g;
         my $keepalive         = $self->{'keepalive'} ? 1 : 0;
@@ -283,13 +289,14 @@ sub api_request {
         };
         local $SIG{'PIPE'} = sub { $hassigpipe = 1; };
         $orig_alarm = alarm($timeout);
+        my @connection_args = ( PeerHost => $remote_server, PeerPort => $port, SSL_verify_mode => 0 );
         while ( ++$attempts < 3 ) {
             $hassigpipe = 0;
-            if ( !ref $whm_sock || !$whm_sock_host || $whm_sock_host != $connection_string ) {
+            if ( !ref $whm_sock || !$whm_sock_host || $whm_sock_host ne $connection_string ) {
                 close($whm_sock) if ref $whm_sock;
                 $whm_sock =
                   $self->{'usessl'}
-                  ? IO::Socket::SSL->new($connection_string)
+                  ? IO::Socket::SSL->new(@connection_args)
                   : IO::Socket::INET->new($connection_string);
                 if ( !$whm_sock ) {
                     undef $whm_sock;
@@ -324,16 +331,17 @@ sub api_request {
 
             if ($hassigpipe) { undef $whm_sock_host; next; }    # http spec says to reconnect
 
-            my $inheaders  = 1;
-            my $httpheader = readline($whm_sock);
+            my $inheaders   = 1;
+            my $httpheader  = readline($whm_sock);
+            my $http_status = $httpheader;
 
-            $self->debug("HTTP LINE[$httpheader]") if $self->{'debug'};
+            $self->debug("HTTP STATUS[$http_status]") if $self->{'debug'};
 
             if ( $hassigpipe || !$httpheader ) { undef $whm_sock_host; next; }    # http spec says to reconnect
 
             my %HEADERS;
             {
-                local $/ = "\r\n\r\n";
+                local $/ = ( $httpheader =~ tr/\r// ) ? "\r\n\r\n" : "\n\n";
                 %HEADERS = map { ( lc $_->[0], substr( $_->[1], 0, 8190 ) ) }     # lc the header and truncate the value to 8190 bytes
                   map { [ ( split( /:\s*/, $_, 2 ) )[ 0, 1 ] ] }                  # split header into name, value - and place into an arrayref for the next map to alter
                   split( /\r?\n/, readline($whm_sock) );                          # split each header
@@ -378,16 +386,13 @@ sub api_request {
                 elsif ( defined $HEADERS{'content-length'} ) {
                     $self->debug("READ TYPE=content-length") if $self->{'debug'};
                     my $bytes_to_read = int $HEADERS{'content-length'};
-                    my $bytes_read = read( $whm_sock, $page, $bytes_to_read ) if $bytes_to_read;
-                    if ( $bytes_to_read && $bytes_read < $bytes_to_read ) {
-                        $bytes_to_read -= $bytes_read;
-                        my $page_buffer;
-                        while ( $bytes_read = read( $whm_sock, $page_buffer, $bytes_to_read ) ) {
-                            $bytes_to_read -= $bytes_read;
-                            $page .= $page_buffer;
-                            last if !$bytes_to_read;
+                    my $bytes_read = $bytes_to_read ? read( $whm_sock, $page, $bytes_to_read ) : 0;
+                    if ( ( $bytes_to_read -= $bytes_read ) > 0 ) {
+                        while ( $bytes_read = read( $whm_sock, $page, $bytes_to_read, length $page ) ) {
+                            last if !$bytes_read || !( $bytes_to_read -= $bytes_read );
                         }
                     }
+                    $self->debug("READ TYPE=content-length: Failed to read response from server.  The connection was dropped with $bytes_to_read bytes left: $!\n") if $self->{'debug'} && $bytes_to_read;
                     $keepalive = 0 if exists $HEADERS{'connection'} && $HEADERS{'connection'} =~ /close/i;
                 }
                 else {
@@ -398,9 +403,9 @@ sub api_request {
                 }
             }
 
-            if ( $httpheader !~ m/^\S+\s+2/ ) {
+            if ( $http_status !~ m/^HTTP\/1\.(0|1) 2/ ) {
                 $keepalive = 0;
-                $self->error("Server Error from $remote_server: ${httpheader}");
+                $self->error("Server Error from $remote_server: $http_status");
             }
 
             if ( !$keepalive ) {
@@ -523,8 +528,8 @@ sub _init_serializer {
         [ 'JSON::XS',   'json', \&JSON::XS::decode_json, 0 ],
         [ 'JSON::PP',   'json', \&JSON::PP::decode_json, 0 ],
       ) {
-        my $serializer_module = $serializer->[0];
-        my $serializer_key    = $serializer->[1];
+        my $serializer_module        = $serializer->[0];
+        my $serializer_key           = $serializer->[1];
         $CFG{'api_serializer_obj'}   = $serializer->[2];
         $CFG{'serializer_can_deref'} = $serializer->[3];
         eval " require $serializer_module; ";
@@ -550,7 +555,7 @@ sub _init {
 
     # moved this over to a pattern to allow easy change of deps
     foreach my $encoder (
-        [ 'cPanel/CPAN/URI/Escape.pm', \&cPanel::CPAN::URI::Escape::uri_escape ],
+        [ 'Cpanel/CPAN/URI/Escape.pm', \&Cpanel::CPAN::URI::Escape::uri_escape ],
         [ 'URI/Escape.pm',             \&URI::Escape::uri_escape ],
       ) {
         my $module   = $encoder->[0];

--- a/lib/cPanel/PublicAPI.pod
+++ b/lib/cPanel/PublicAPI.pod
@@ -122,15 +122,15 @@ There are two sets of credentials that can be used to authenticate to WHM.
 
 First we have the basic user/password combinations:
 
-  use Cpanel::PublicAPI;
-  my $pubapi = Cpanel::PublicAPI->new( 'user' => 'foo', 'password' => 'bar' );
+  use cPanel::PublicAPI;
+  my $pubapi = cPanel::PublicAPI->new( 'user' => 'foo', 'password' => 'bar' );
 
 The other type of authentication is accesshash authentication.  To configure accesshashes visit “Setup remote access key”
 in WHM which will generate an accesshash for your server if one does not already exist. It will store the generated accesshash
 in /root/.accesshash.  To use an accesshash with this module you can do something like the following:
 
-  use Cpanel::PublicAPI;
-  my $pubapi = Cpanel::PublicAPI->new( 'user' => 'foo', 'accesshash' => $string_containing_access_hash );
+  use cPanel::PublicAPI;
+  my $pubapi = cPanel::PublicAPI->new( 'user' => 'foo', 'accesshash' => $string_containing_access_hash );
 
 It should be noted that the access hash can contain newlines in it,  Newlines will be stripped by the object when
 it attempts to perform a query.
@@ -338,7 +338,7 @@ see http://rt.cpan.org to report and view bugs
 
 =head1 License
 
-Copyright (c) 2011, cPanel, Inc.
+Copyright (c) 2015, cPanel, Inc.
 All rights reserved.
 http://cpanel.net
 

--- a/lib/cPanel/PublicAPI/Utils.pm
+++ b/lib/cPanel/PublicAPI/Utils.pm
@@ -1,30 +1,33 @@
 package cPanel::PublicAPI::Utils;
 
-# Copyright (c) 2011, cPanel, Inc.
+# Copyright (c) 2015, cPanel, Inc.
 # All rights reserved.
 # http://cpanel.net
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-#    * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#     * Neither the name of cPanel, Inc. nor the
-#       names of its contributors may be used to endorse or promote products
-#       derived from this software without specific prior written permission.
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the owner nor the names of its contributors may be
+# used to endorse or promote products derived from this software without
+# specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL  BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 sub remove_trailing_newline {
     my $string = shift;
@@ -33,7 +36,7 @@ sub remove_trailing_newline {
 }
 
 sub get_string_with_collapsed_trailing_eols {
-    my @copy = @_;    # this addresses 'Modification of a read-only value attempted at cPanel/Accounting.pm ...' from $line =~ below
+    my @copy = @_;    # this addresses 'Modification of a read-only value attempted at Cpanel/Accounting.pm ...' from $line =~ below
     my $txt;
     foreach my $line (@copy) {
         if ( ref $line eq 'ARRAY' ) {

--- a/lib/cPanel/PublicAPI/Utils.pod
+++ b/lib/cPanel/PublicAPI/Utils.pod
@@ -18,7 +18,7 @@ see http://rt.cpan.org to report and view bugs
 
 =head1 License
 
-Copyright (c) 2011, cPanel, Inc.
+Copyright (c) 2015, cPanel, Inc.
 All rights reserved.
 http://cpanel.net
 

--- a/lib/cPanel/PublicAPI/WHM.pm
+++ b/lib/cPanel/PublicAPI/WHM.pm
@@ -1,30 +1,33 @@
 package cPanel::PublicAPI::WHM;
 
-# Copyright (c) 2011, cPanel, Inc.
+# Copyright (c) 2015, cPanel, Inc.
 # All rights reserved.
 # http://cpanel.net
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-#    * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#     * Neither the name of cPanel, Inc. nor the
-#       names of its contributors may be used to endorse or promote products
-#       derived from this software without specific prior written permission.
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the owner nor the names of its contributors may be
+# used to endorse or promote products derived from this software without
+# specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL  BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use cPanel::PublicAPI ();
 
@@ -43,7 +46,7 @@ sub simple_get_whmreq {
     if ( !$opts || !ref $opts ) { $opts = []; }
     if ( ref $argnameref ) {
         foreach my $arg ( @{$argnameref} ) {
-            push @{$opts}, $cPanel::PublicAPI::CFG{'uri_encoder_func'}->($arg) . '=' . $cPanel::PublicAPI::CFG{'uri_encoder_func'}->( $argref->[$count] );
+            push @{$opts}, $cPanel::PublicAPI::CFG{'uri_encoder_func'}->($arg) . '=' . ( $cPanel::PublicAPI::CFG{'uri_encoder_func'}->( $argref->[$count] ) || '' );
             $count++;
         }
     }
@@ -87,7 +90,7 @@ sub whmreq {
     return wantarray ? split( /\r?\n/, $$data ) : $$data;
 }
 
-sub api1 {    #cPanel::Accounting compat
+sub api1 {    #Cpanel::Accounting compat
     my $self   = shift;
     my $user   = shift;
     my $module = shift;
@@ -95,7 +98,7 @@ sub api1 {    #cPanel::Accounting compat
     return $self->cpanel_api1_request( 'whostmgr', { 'user' => $user, 'module' => $module, 'func' => $func }, \@_, 'xml' );
 }
 
-sub api2 {    #cPanel::Accounting compat
+sub api2 {    #Cpanel::Accounting compat
     my $self   = shift;
     my $user   = shift;
     my $module = shift;

--- a/lib/cPanel/PublicAPI/WHM.pod
+++ b/lib/cPanel/PublicAPI/WHM.pod
@@ -125,7 +125,7 @@ see http://rt.cpan.org to report and view bugs
 
 =head1 License
 
-Copyright (c) 2011, cPanel, Inc.
+Copyright (c) 2015, cPanel, Inc.
 All rights reserved.
 http://cpanel.net
 

--- a/lib/cPanel/PublicAPI/WHM/API.pm
+++ b/lib/cPanel/PublicAPI/WHM/API.pm
@@ -1,30 +1,33 @@
 package cPanel::PublicAPI::API;
 
-# Copyright (c) 2011, cPanel, Inc.
+# Copyright (c) 2015, cPanel, Inc.
 # All rights reserved.
 # http://cpanel.net
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-#    * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#     * Neither the name of cPanel, Inc. nor the
-#       names of its contributors may be used to endorse or promote products
-#       derived from this software without specific prior written permission.
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the owner nor the names of its contributors may be
+# used to endorse or promote products derived from this software without
+# specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL  BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use cPanel::PublicAPI ();
 our $VERSION = 1.0;
@@ -266,7 +269,7 @@ sub api_listsuspended {
 
 sub api_addpkg {
     my $self = shift;
-    return $self->serialize( $self->simple_get_whmreq( '/' . $cPanel::PublicAPI::CFG{'serializer'} . '-api/addpkg', \@_, [ 'pkgname', 'quota', 'ip', 'cgi', 'frontpage', 'cpmod', 'maxftp', 'maxsql', 'maxpop', 'maxlst', 'maxsub', 'maxpark', 'maxaddon', 'featurelist', 'hasshell', 'bwlimit' ] ) );
+    return $self->serialize( $self->simple_get_whmreq( '/' . $cPanel::PublicAPI::CFG{'serializer'} . '-api/addpkg', \@_, [ 'pkgname', 'quota', 'ip', 'cgi', 'cpmod', 'maxftp', 'maxsql', 'maxpop', 'maxlst', 'maxsub', 'maxpark', 'maxaddon', 'featurelist', 'hasshell', 'bwlimit' ] ) );
 }
 
 sub api_killpkg {
@@ -276,7 +279,7 @@ sub api_killpkg {
 
 sub api_editpkg {
     my $self = shift;
-    return $self->serialize( $self->simple_get_whmreq( '/' . $cPanel::PublicAPI::CFG{'serializer'} . '-api/editpkg', \@_, [ 'pkgname', 'quota', 'ip', 'cgi', 'frontpage', 'cpmod', 'maxftp', 'maxsql', 'maxpop', 'maxlst', 'maxsub', 'maxpark', 'maxaddon', 'featurelist', 'hasshell', 'bwlimit' ] ) );
+    return $self->serialize( $self->simple_get_whmreq( '/' . $cPanel::PublicAPI::CFG{'serializer'} . '-api/editpkg', \@_, [ 'pkgname', 'quota', 'ip', 'cgi', 'cpmod', 'maxftp', 'maxsql', 'maxpop', 'maxlst', 'maxsub', 'maxpark', 'maxaddon', 'featurelist', 'hasshell', 'bwlimit' ] ) );
 }
 
 sub api_setacls {

--- a/lib/cPanel/PublicAPI/WHM/API.pod
+++ b/lib/cPanel/PublicAPI/WHM/API.pod
@@ -573,7 +573,7 @@ see http://rt.cpan.org to report and view bugs
 
 =head1 License
 
-Copyright (c) 2011, cPanel, Inc.
+Copyright (c) 2015, cPanel, Inc.
 All rights reserved.
 http://cpanel.net
 

--- a/lib/cPanel/PublicAPI/WHM/CachedVersion.pm
+++ b/lib/cPanel/PublicAPI/WHM/CachedVersion.pm
@@ -1,30 +1,33 @@
 package cPanel::PublicAPI::WHM::CachedVersion;
 
-# Copyright (c) 2011, cPanel, Inc.
+# Copyright (c) 2015, cPanel, Inc.
 # All rights reserved.
 # http://cpanel.net
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-#    * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#     * Neither the name of cPanel, Inc. nor the
-#       names of its contributors may be used to endorse or promote products
-#       derived from this software without specific prior written permission.
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the owner nor the names of its contributors may be
+# used to endorse or promote products derived from this software without
+# specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL  BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use cPanel::PublicAPI ();
 

--- a/lib/cPanel/PublicAPI/WHM/CachedVersion.pod
+++ b/lib/cPanel/PublicAPI/WHM/CachedVersion.pod
@@ -25,7 +25,7 @@ see http://rt.cpan.org to report and view bugs
 
 =head1 License
 
-Copyright (c) 2011, cPanel, Inc.
+Copyright (c) 2015, cPanel, Inc.
 All rights reserved.
 http://cpanel.net
 

--- a/lib/cPanel/PublicAPI/WHM/DNS.pm
+++ b/lib/cPanel/PublicAPI/WHM/DNS.pm
@@ -1,30 +1,33 @@
 package cPanel::PublicAPI::DNS;
 
-# Copyright (c) 2011, cPanel, Inc.
+# Copyright (c) 2015, cPanel, Inc.
 # All rights reserved.
 # http://cpanel.net
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-#    * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#     * Neither the name of cPanel, Inc. nor the
-#       names of its contributors may be used to endorse or promote products
-#       derived from this software without specific prior written permission.
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the owner nor the names of its contributors may be
+# used to endorse or promote products derived from this software without
+# specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL  BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use cPanel::PublicAPI ();
 
@@ -138,4 +141,3 @@ sub zoneexists_local {
     }
     return 0;
 }
-

--- a/lib/cPanel/PublicAPI/WHM/DNS.pod
+++ b/lib/cPanel/PublicAPI/WHM/DNS.pod
@@ -196,7 +196,7 @@ see http://rt.cpan.org to report and view bugs
 
 =head1 License
 
-Copyright (c) 2011, cPanel, Inc.
+Copyright (c) 2015, cPanel, Inc.
 All rights reserved.
 http://cpanel.net
 

--- a/lib/cPanel/PublicAPI/WHM/JSONAPI.pm
+++ b/lib/cPanel/PublicAPI/WHM/JSONAPI.pm
@@ -1,30 +1,33 @@
 package cPanel::PublicAPI::JSONAPI;
 
-# Copyright (c) 2011, cPanel, Inc.
+# Copyright (c) 2015, cPanel, Inc.
 # All rights reserved.
 # http://cpanel.net
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-#    * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#     * Neither the name of cPanel, Inc. nor the
-#       names of its contributors may be used to endorse or promote products
-#       derived from this software without specific prior written permission.
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the owner nor the names of its contributors may be
+# used to endorse or promote products derived from this software without
+# specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL  BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use cPanel::PublicAPI ();
 
@@ -39,4 +42,3 @@ foreach my $sub ( grep ( /^api_/, keys %cPanel::PublicAPI:: ) ) {
 }
 
 1;
-

--- a/lib/cPanel/PublicAPI/WHM/JSONAPI.pod
+++ b/lib/cPanel/PublicAPI/WHM/JSONAPI.pod
@@ -573,7 +573,7 @@ see http://rt.cpan.org to report and view bugs
 
 =head1 License
 
-Copyright (c) 2011, cPanel, Inc.
+Copyright (c) 2015, cPanel, Inc.
 All rights reserved.
 http://cpanel.net
 

--- a/lib/cPanel/PublicAPI/WHM/Legacy.pm
+++ b/lib/cPanel/PublicAPI/WHM/Legacy.pm
@@ -1,30 +1,33 @@
 package cPanel::PublicAPI::Legacy;
 
-# Copyright (c) 2011, cPanel, Inc.
+# Copyright (c) 2015, cPanel, Inc.
 # All rights reserved.
 # http://cpanel.net
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-#    * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#     * Neither the name of cPanel, Inc. nor the
-#       names of its contributors may be used to endorse or promote products
-#       derived from this software without specific prior written permission.
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the owner nor the names of its contributors may be
+# used to endorse or promote products derived from this software without
+# specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL  BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use cPanel::PublicAPI ();
 
@@ -40,7 +43,7 @@ sub _modpkg {
     my $count = 0;
     my @OPTS  = ('nohtml=1');
     if ( $op eq 'edit' ) { push @OPTS, 'edit=yes'; }
-    return $self->simple_get_whmreq( '/scripts/addpkg', \@_, [ 'name', 'hasshell', 'bwlimit', 'quota', 'ip', 'cgi', 'frontpage', 'cpmod', 'maxftp', 'maxsql', 'maxpop', 'maxlst', 'maxsub', 'maxpark', 'maxaddon', 'featurelist', 'language' ], \@OPTS );
+    return $self->simple_get_whmreq( '/scripts/addpkg', \@_, [ 'name', 'hasshell', 'bwlimit', 'quota', 'ip', 'cgi', 'cpmod', 'maxftp', 'maxsql', 'maxpop', 'maxlst', 'maxsub', 'maxpark', 'maxaddon', 'featurelist', 'language' ], \@OPTS );
 }
 
 sub addpkg {
@@ -110,6 +113,7 @@ sub listaccts {
     my $req = $self->simple_get_whmreq( '/scripts2/listaccts', \@_, [], ['nohtml=1&viewall=1'] );
     my %ACCTS;
     foreach ( split( /\n/, $req ) ) {
+        next if $_ !~ /=/;
         my ( $acct, $contents ) = split( /=/, $_ );
         my @CONTENTS = split( /\,/, $contents );
         $ACCTS{$acct} = \@CONTENTS;

--- a/lib/cPanel/PublicAPI/WHM/Legacy.pod
+++ b/lib/cPanel/PublicAPI/WHM/Legacy.pod
@@ -12,7 +12,7 @@ see http://rt.cpan.org to report and view bugs
 
 =head1 License
 
-Copyright (c) 2011, cPanel, Inc.
+Copyright (c) 2015, cPanel, Inc.
 All rights reserved.
 http://cpanel.net
 

--- a/lib/cPanel/PublicAPI/WHM/XMLAPI.pm
+++ b/lib/cPanel/PublicAPI/WHM/XMLAPI.pm
@@ -1,30 +1,33 @@
 package cPanel::PublicAPI::XMLAPI;
 
-# Copyright (c) 2011, cPanel, Inc.
+# Copyright (c) 2015, cPanel, Inc.
 # All rights reserved.
 # http://cpanel.net
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-#    * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#     * Neither the name of cPanel, Inc. nor the
-#       names of its contributors may be used to endorse or promote products
-#       derived from this software without specific prior written permission.
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the owner nor the names of its contributors may be
+# used to endorse or promote products derived from this software without
+# specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL  BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use cPanel::PublicAPI ();
 
@@ -39,4 +42,3 @@ foreach my $sub ( grep ( /^api_/, keys %cPanel::PublicAPI:: ) ) {
 }
 
 1;
-

--- a/lib/cPanel/PublicAPI/WHM/XMLAPI.pod
+++ b/lib/cPanel/PublicAPI/WHM/XMLAPI.pod
@@ -573,7 +573,7 @@ see http://rt.cpan.org to report and view bugs
 
 =head1 License
 
-Copyright (c) 2011, cPanel, Inc.
+Copyright (c) 2015, cPanel, Inc.
 All rights reserved.
 http://cpanel.net
 

--- a/t/02-construct.t
+++ b/t/02-construct.t
@@ -19,13 +19,14 @@ if ( !-e $homedir . '/.accesshash' ) {
 
 check_options();
 check_options( 'debug' => 1, 'error_log' => '/dev/null' );
-check_options( 'timeout'   => 150 );
-check_options( 'usessl'    => 0 );
-check_options( 'ip'        => '4.2.2.2' );
-check_options( 'host'      => 'zomg.cpanel.net' );
-check_options( 'error_log' => '/dev/null' );
-check_options( 'user'      => 'bar' );
-check_options( 'pass'      => 'f00!3Df@' );
+check_options( 'timeout'         => 150 );
+check_options( 'usessl'          => 0 );
+check_options( 'ssl_verify_mode' => 0 );
+check_options( 'ip'              => '4.2.2.2' );
+check_options( 'host'            => 'zomg.cpanel.net' );
+check_options( 'error_log'       => '/dev/null' );
+check_options( 'user'            => 'bar' );
+check_options( 'pass'            => 'f00!3Df@' );
 my $accesshash = 'sdflkjl
 sdafjkl
 sdlfkjh';
@@ -64,7 +65,7 @@ is( $pubapi->{'accesshash'}, 'onetwothreefour', 'accesshash accessor' );
 ok( !exists $pubapi->{'pass'}, 'accesshash accessor deletes pass scalar' );
 
 my $header_string = $pubapi->format_http_headers( { 'Authorization' => 'Basic cm9vdDpsMGx1cnNtNHJ0IQ==' } );
-is($header_string, "Authorization: Basic cm9vdDpsMGx1cnNtNHJ0IQ==\r\n", 'format_http_headers is ok');
+is( $header_string, "Authorization: Basic cm9vdDpsMGx1cnNtNHJ0IQ==\r\n", 'format_http_headers is ok' );
 
 can_ok( $pubapi, 'new', 'set_debug', 'user', 'pass', 'accesshash', 'whm_api', 'api_request', 'cpanel_api1_request', 'cpanel_api2_request', '_total_form_length', '_init_serializer', '_init', 'error', 'debug', 'format_http_query' );
 
@@ -96,6 +97,13 @@ sub check_options {
     }
     else {
         is( $pubapi->{'usessl'}, 1, 'usessl default' );
+    }
+
+    if ( defined $OPTS{'ssl_verify_mode'} ) {
+        is( $pubapi->{'ssl_verify_mode'}, $OPTS{'ssl_verify_mode'}, 'ssl_verify_mode constructor option' );
+    }
+    else {
+        is( $pubapi->{'ssl_verify_mode'}, 1, 'ssl_verify_mode default' );
     }
 
     if ( defined $OPTS{'ip'} ) {

--- a/t/03-api-query.t
+++ b/t/03-api-query.t
@@ -20,7 +20,7 @@ if ( !-e $homedir . '/.accesshash' ) {
 }
 
 # SSL tests
-my $pubapi = cPanel::PublicAPI->new();
+my $pubapi = cPanel::PublicAPI->new( 'ssl_verify_mode' => 0 );
 
 isa_ok( $pubapi, 'cPanel::PublicAPI' );
 
@@ -44,7 +44,6 @@ like( $$res, $createacct_regex, 'ssl whm post string params' );
 
 # Create account for cpanel & reseller testing
 
-
 if ( !-e '/var/cpanel/users/papiunit' ) {
     my $password = generate_password();
     $res = $pubapi->api_request(
@@ -63,8 +62,9 @@ if ( !-e '/var/cpanel/users/papiunit' ) {
     # skip is not used here due to the other code contained within this block.
     if ( $$res =~ /Account Creation Ok/ ) {
         my $cp_pubapi = cPanel::PublicAPI->new(
-            'user' => 'papiunit',
-            'pass' => $password,
+            'user'            => 'papiunit',
+            'pass'            => $password,
+            'ssl_verify_mode' => 0,
         );
         isa_ok( $cp_pubapi, 'cPanel::PublicAPI' );
         $res = $cp_pubapi->api_request( 'cpanel', '/xml-api/cpanel', 'GET', 'cpanel_xmlapi_module=StatsBar&cpanel_xmlapi_func=stat&display=diskusage' );

--- a/t/03-api-query.t
+++ b/t/03-api-query.t
@@ -28,7 +28,7 @@ my $res = $pubapi->api_request( 'whostmgr', '/xml-api/loadavg', 'GET', {} );
 like( $$res, qr/<loadavg>\s*<one>\d+\.\d+<\/one>\s*<five>\d+\.\d+<\/five>\s*<fifteen>\d+\.\d+<\/fifteen>\s*<\/loadavg>*/, 'whm get no params' );
 
 # Create the test regex for reuse
-my $createacct_regex = qr/<statusmsg>Sorry, that username is reserved\.<\/statusmsg>/;
+my $createacct_regex = qr/<statusmsg>.*is a reserved username.*<\/statusmsg>/;
 
 $res = $pubapi->api_request( 'whostmgr', '/xml-api/createacct', 'GET', { 'username' => 'test', 'domain' => 'test.com' } );
 like( $$res, $createacct_regex, 'ssl whm get hash params' );


### PR DESCRIPTION
	Fixed non-numeric comparison errors.
	Cleaned up uninitialized variable use.
	Error checking after api_request in cPanel::PublicAPI::whm_api() call.
	Correct comments in copyright headers w/ modified bsd license
	Correct disclaimer in 3-clause BSD license
	Changes to accommodate latest version of IO::Socket::SSL
	Removed Frontpage references
	Changed to work with self-signed SSL certificates