### PR TITLE
Fix hash randomization issue.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for cPanel-PublicAPI
 
+1.3 2015-09-14
+    Fix hash randomization problem on newer Perls.
+
 1.2	8/26/2015
 	Updated from main code-base, changes include:
 		Fixed non-numeric comparison errors.

--- a/lib/cPanel/PublicAPI.pm
+++ b/lib/cPanel/PublicAPI.pm
@@ -29,7 +29,7 @@ package cPanel::PublicAPI;
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-our $VERSION = 1.2;
+our $VERSION = 1.3;
 
 use strict;
 use Socket           ();
@@ -606,7 +606,7 @@ sub format_http_headers {
 sub format_http_query {
     my ( $self, $formdata ) = @_;
     if ( ref $formdata ) {
-        return join( '&', map { $CFG{'uri_encoder_func'}->($_) . '=' . $CFG{'uri_encoder_func'}->( $formdata->{$_} ) } keys %{$formdata} );
+        return join( '&', map { $CFG{'uri_encoder_func'}->($_) . '=' . $CFG{'uri_encoder_func'}->( $formdata->{$_} ) } sort keys %{$formdata} );
     }
     return $formdata;
 }


### PR DESCRIPTION
The testsuite was expecting format_http_headers to produce sorted
output, but that function was using the default key order.  Since the
order doesn't matter, sort the keys so that format_http_query produces
consistent output.