### PR TITLE
Default WHM API to v1.

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for cPanel-PublicAPI
 1.4 2015-09-15
     Updated PublicAPI pod file to include description
     of new ssl_verify_mode option.
+    Default WHM API to v1.
 
 1.3 2015-09-14
     Fix hash randomization problem on newer Perls.

--- a/lib/cPanel/PublicAPI.pm
+++ b/lib/cPanel/PublicAPI.pm
@@ -29,7 +29,7 @@ package cPanel::PublicAPI;
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-our $VERSION = 1.3;
+our $VERSION = 1.4;
 
 use strict;
 use Socket           ();
@@ -181,6 +181,15 @@ sub whm_api {
     if ( defined $format && $format ne 'xml' && $format ne 'json' && $format ne 'ref' ) {
         $self->error("cPanel::PublicAPI::whm_api_request() was called with an invalid data format, the only valid format are 'json', 'ref' or 'xml'");
     }
+
+    $formdata ||= {};
+    if ( ref $formdata ) {
+        $formdata = { 'api.version' => 1, %$formdata };
+    }
+    elsif ( $formdata !~ /(^|&)api\.version=/ ) {
+        $formdata = "api.version=1&$formdata";
+    }
+
     my $query_format;
     if ( defined $format ) {
         $query_format = $format;

--- a/lib/cPanel/PublicAPI.pod
+++ b/lib/cPanel/PublicAPI.pod
@@ -178,6 +178,9 @@ The meaning of these parameters is:
 
 =back
 
+By default, WHM API v1 is used.  If, for legacy reasons, you need to use v0,
+please set the C<api.version> key to 0 in the formdata parameter.
+
 For more information on what calls are available and how they can be referenced, please see the xml-api documentation at L<http://docs.cpanel.net/twiki/bin/view/AllDocumentation/AutomationIntegration/XmlApi>.
 
 =head2 Querying cPanel's APIs

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -3,8 +3,8 @@
 use Test::More tests => 1;
 
 BEGIN {
-    use_ok( 'cPanel::PublicAPI' ) || print "Bail out!
+    use_ok('cPanel::PublicAPI') || print "Bail out!
 ";
 }
 
-diag( "Testing cPanel::PublicAPI $cPanel::PublicAPI::VERSION, Perl $], $^X" );
+diag("Testing cPanel::PublicAPI $cPanel::PublicAPI::VERSION, Perl $], $^X");

--- a/t/01-api-format.t
+++ b/t/01-api-format.t
@@ -3,14 +3,14 @@
 use strict;
 use warnings;
 
-use Test::More;                      # last test to print
+use Test::More;    # last test to print
 
 use lib 't/lib';
 
 use PubApiTest ();
 
-my $pubapi = PubApiTest->new( 
-    'ip'        => '127.0.0.1', 
+my $pubapi = PubApiTest->new(
+    'ip'        => '127.0.0.1',
     'usessl'    => 1,
     'user'      => 'someuser',
     'pass'      => 'somepass',
@@ -19,131 +19,132 @@ my $pubapi = PubApiTest->new(
 
 # test WHM
 $PubApiTest::test_config = {
-    'service' => 'whostmgr',
-    'uri'   => '/json-api/loadavg',
-    'method' => 'POST',
-    'call'  => 'whm_api-noform',
+    'service'       => 'whostmgr',
+    'uri'           => '/json-api/loadavg',
+    'method'        => 'POST',
+    'call'          => 'whm_api-noform',
     'return_format' => 'json',
 };
 my $res = $pubapi->whm_api('loadavg');
 is( ref $res, 'HASH', 'Returned format ok for ' . $PubApiTest::test_config->{'call'} );
 
 $PubApiTest::test_config->{'test_formdata'} = 'hash';
-$PubApiTest::test_config->{'formdata'} = { 'key' => 'value' };
-$PubApiTest::test_config->{'call'} = 'whm_api-refform';
-$res = $pubapi->whm_api('loadavg', $PubApiTest::test_config->{'formdata'} );
+$PubApiTest::test_config->{'formdata'}      = { 'key' => 'value' };
+$PubApiTest::test_config->{'call'}          = 'whm_api-refform';
+$res = $pubapi->whm_api( 'loadavg', $PubApiTest::test_config->{'formdata'} );
 is( ref $res, 'HASH', 'Returned format ok for ' . $PubApiTest::test_config->{'call'} );
 
 $PubApiTest::test_config->{'test_formdata'} = 'string';
-$PubApiTest::test_config->{'formdata'} = 'one&two';
-$PubApiTest::test_config->{'call'} = 'whm_api-stringform';
-$res = $pubapi->whm_api('loadavg', $PubApiTest::test_config->{'formdata'} );
+$PubApiTest::test_config->{'formdata'}      = 'one&two';
+$PubApiTest::test_config->{'call'}          = 'whm_api-stringform';
+$res = $pubapi->whm_api( 'loadavg', $PubApiTest::test_config->{'formdata'} );
 is( ref $res, 'HASH', 'Returned format ok for ' . $PubApiTest::test_config->{'call'} );
 
 delete $PubApiTest::test_config->{'formdata'};
 delete $PubApiTest::test_config->{'test_formdata'};
 $PubApiTest::test_config->{'return_format'} = 'json';
-$res = $pubapi->whm_api('loadavg', undef, 'json' );
+$res = $pubapi->whm_api( 'loadavg', undef, 'json' );
 is( $res, '{"something":"somethinglese"}', 'raw JSON data returned raw correctly from whm_api' );
 
-$PubApiTest::test_config->{'test_format'} = 'xml';
+$PubApiTest::test_config->{'test_format'}   = 'xml';
 $PubApiTest::test_config->{'return_format'} = 'xml';
-$PubApiTest::test_config->{'uri'} = '/xml-api/loadavg';
-$res = $pubapi->whm_api('loadavg', undef, 'xml' );
+$PubApiTest::test_config->{'uri'}           = '/xml-api/loadavg';
+$res = $pubapi->whm_api( 'loadavg', undef, 'xml' );
 is( $res, '<node><something>somethingelse</something></node>', 'raw XML data returned raw correctly from whm_api' );
 
-# test API1 
+# test API1
 $PubApiTest::test_config = {
-    'service' => 'cpanel',
-    'uri'   => '/json-api/cpanel',
-    'method' => 'GET',
-    'call'  => 'api1-noargs',
+    'service'       => 'cpanel',
+    'uri'           => '/json-api/cpanel',
+    'method'        => 'GET',
+    'call'          => 'api1-noargs',
     'return_format' => 'json',
     'test_formdata' => 'hash',
-    
+
 };
 
 # Without arguments
 $PubApiTest::test_config->{'formdata'} = {
-    'cpanel_jsonapi_module' => 'Test',
-    'cpanel_jsonapi_func' => 'test',
+    'cpanel_jsonapi_module'     => 'Test',
+    'cpanel_jsonapi_func'       => 'test',
     'cpanel_jsonapi_apiversion' => 1,
 };
 
 my $call_config = {
     'module' => 'Test',
-    'func'  => 'test',
+    'func'   => 'test',
 };
 
-$res = $pubapi->cpanel_api1_request('cpanel', $call_config );
+$res = $pubapi->cpanel_api1_request( 'cpanel', $call_config );
 is( ref $res, 'HASH', 'Returned format ok for ' . $PubApiTest::test_config->{'call'} );
 
 # with arguments
-$PubApiTest::test_config->{'call'} = 'api1-args';
+$PubApiTest::test_config->{'call'}                = 'api1-args';
 $PubApiTest::test_config->{'formdata'}->{'arg-0'} = 'one';
 $PubApiTest::test_config->{'formdata'}->{'arg-1'} = 'two';
-$res = $pubapi->cpanel_api1_request('cpanel', $call_config, [ 'one', 'two' ] );
+$res = $pubapi->cpanel_api1_request( 'cpanel', $call_config, [ 'one', 'two' ] );
 is( ref $res, 'HASH', 'Returned format ok for ' . $PubApiTest::test_config->{'call'} );
 
 # WHM
 
 # with arguments
-$PubApiTest::test_config->{'call'} = 'whm-api1-args';
+$PubApiTest::test_config->{'call'}                              = 'whm-api1-args';
 $PubApiTest::test_config->{'formdata'}->{'cpanel_jsonapi_user'} = 'someuser';
-$PubApiTest::test_config->{'service'} = 'whostmgr';
-$call_config->{'user'} = 'someuser';
-$res = $pubapi->cpanel_api1_request('whostmgr', $call_config, [ 'one', 'two' ] );
+$PubApiTest::test_config->{'service'}                           = 'whostmgr';
+$call_config->{'user'}                                          = 'someuser';
+$res = $pubapi->cpanel_api1_request( 'whostmgr', $call_config, [ 'one', 'two' ] );
 is( ref $res, 'HASH', 'Returned format ok for ' . $PubApiTest::test_config->{'call'} );
 
 # without arguments
 $PubApiTest::test_config->{'call'} = 'whm-api1-noargs';
 delete $PubApiTest::test_config->{'formdata'}->{'arg-1'};
 delete $PubApiTest::test_config->{'formdata'}->{'arg-0'};
-$res = $pubapi->cpanel_api1_request('whostmgr', $call_config );
+$res = $pubapi->cpanel_api1_request( 'whostmgr', $call_config );
 is( ref $res, 'HASH', 'Returned format ok for ' . $PubApiTest::test_config->{'call'} );
 
 # Test JSON
-$PubApiTest::test_config->{'call'} = 'whm-api1-rawjson';
+$PubApiTest::test_config->{'call'}          = 'whm-api1-rawjson';
 $PubApiTest::test_config->{'return_format'} = 'json';
-$res = $pubapi->cpanel_api1_request('whostmgr', $call_config, undef, 'json' );
+$res = $pubapi->cpanel_api1_request( 'whostmgr', $call_config, undef, 'json' );
 is( $res, '{"something":"somethinglese"}', 'raw JSON data returned raw correctly from cpanel_api1_request' );
 
 # Test XML
-$PubApiTest::test_config->{'call'} = 'whm-api1-rawxml';
-$PubApiTest::test_config->{'test_format'} = 'xml';
+$PubApiTest::test_config->{'call'}          = 'whm-api1-rawxml';
+$PubApiTest::test_config->{'test_format'}   = 'xml';
 $PubApiTest::test_config->{'return_format'} = 'xml';
-$PubApiTest::test_config->{'uri'} = '/xml-api/cpanel';
+$PubApiTest::test_config->{'uri'}           = '/xml-api/cpanel';
 
 $PubApiTest::test_config->{'formdata'} = {
-    'cpanel_xmlapi_user' => 'someuser',
-    'cpanel_xmlapi_module' => 'Test',
-    'cpanel_xmlapi_func' => 'test',
+    'cpanel_xmlapi_user'       => 'someuser',
+    'cpanel_xmlapi_module'     => 'Test',
+    'cpanel_xmlapi_func'       => 'test',
     'cpanel_xmlapi_apiversion' => '1',
 };
 
-$res = $pubapi->cpanel_api1_request('whostmgr', $call_config, [], 'xml' );
+$res = $pubapi->cpanel_api1_request( 'whostmgr', $call_config, [], 'xml' );
 is( $res, '<node><something>somethingelse</something></node>', 'raw XML data returned raw correctly from cpanel_api1_request' );
 
 # API2
 $PubApiTest::test_config = {
-    'service' => 'cpanel',
-    'uri'   => '/json-api/cpanel',
-    'method' => 'GET',
-    'call'  => 'api2-noargs',
+    'service'       => 'cpanel',
+    'uri'           => '/json-api/cpanel',
+    'method'        => 'GET',
+    'call'          => 'api2-noargs',
     'return_format' => 'json',
     'test_formdata' => 'hash',
 };
 
 $PubApiTest::test_config->{'formdata'} = {
-    'cpanel_jsonapi_func' => 'test',
-    'cpanel_jsonapi_module' => 'Api2Test',
+    'cpanel_jsonapi_func'       => 'test',
+    'cpanel_jsonapi_module'     => 'Api2Test',
     'cpanel_jsonapi_apiversion' => '2',
 };
 
 $call_config = {
     'module' => 'Api2Test',
-    'func'  => 'test',
+    'func'   => 'test',
 };
+
 # without args
 $res = $pubapi->cpanel_api2_request( 'cpanel', $call_config );
 is( ref $res, 'HASH', 'Returned format ok for ' . $PubApiTest::test_config->{'call'} );
@@ -151,12 +152,12 @@ is( ref $res, 'HASH', 'Returned format ok for ' . $PubApiTest::test_config->{'ca
 # with args
 $PubApiTest::test_config->{'call'} = 'whm-api2-args';
 my $args = {
-    'testing' => 'one two three',
+    'testing'     => 'one two three',
     'earth below' => 'us',
 };
 
-foreach my $key ( keys %{ $args } ) {
-    $PubApiTest::test_config->{'formdata'}->{$key} =$args->{$key};
+foreach my $key ( keys %{$args} ) {
+    $PubApiTest::test_config->{'formdata'}->{$key} = $args->{$key};
 }
 
 $res = $pubapi->cpanel_api2_request( 'cpanel', $call_config, $args );
@@ -172,15 +173,15 @@ is( $res, '{"something":"somethinglese"}', 'raw JSON data returned raw correctly
 
 #xml
 
-$PubApiTest::test_config->{'call'} = 'api2-rawxml';
+$PubApiTest::test_config->{'call'}     = 'api2-rawxml';
 $PubApiTest::test_config->{'formdata'} = {
-    'cpanel_xmlapi_module' => 'Api2Test',
-    'cpanel_xmlapi_func' => 'test',
+    'cpanel_xmlapi_module'     => 'Api2Test',
+    'cpanel_xmlapi_func'       => 'test',
     'cpanel_xmlapi_apiversion' => '2'
 };
-$PubApiTest::test_config->{'format'} = 'xml';
+$PubApiTest::test_config->{'format'}        = 'xml';
 $PubApiTest::test_config->{'return_format'} = 'xml';
-$PubApiTest::test_config->{'uri'} = '/xml-api/cpanel';
+$PubApiTest::test_config->{'uri'}           = '/xml-api/cpanel';
 
 $res = $pubapi->cpanel_api2_request( 'cpanel', $call_config, undef, 'xml' );
 is( $res, '<node><something>somethingelse</something></node>', 'raw XML data returned raw correctly from cpanel_api2_request' );
@@ -191,11 +192,11 @@ $pubapi->whm_api('version');
 like( $pubapi->{'error'}, qr/cPanel::PublicAPI::whm_api was called with the invalid API call of/, 'whm_api invalid call checking works' );
 
 $PubApiTest::test_config->{'badcall'} = 'cpanelapi1';
-$pubapi->cpanel_api1_request('cpanel', { 'module' => 'test', 'func' => 'test'} );
+$pubapi->cpanel_api1_request( 'cpanel', { 'module' => 'test', 'func' => 'test' } );
 like( $pubapi->{'error'}, qr/cPanel::PublicAPI::cpanel_api1_request was called with the invalid API1 call of:/, 'cpanel_api1_request invalid call checking works' );
 
 $PubApiTest::test_config->{'badcall'} = 'cpanelapi2';
-$pubapi->cpanel_api2_request('cpanel', { 'module' => 'test', 'func' => 'test'} );
+$pubapi->cpanel_api2_request( 'cpanel', { 'module' => 'test', 'func' => 'test' } );
 like( $pubapi->{'error'}, qr/cPanel::PublicAPI::cpanel_api2_request was called with the invalid API2 call of:/, 'cpanel_api1_request invalid call checking works' );
 
 done_testing();

--- a/t/01-api-format.t
+++ b/t/01-api-format.t
@@ -29,15 +29,33 @@ my $res = $pubapi->whm_api('loadavg');
 is( ref $res, 'HASH', 'Returned format ok for ' . $PubApiTest::test_config->{'call'} );
 
 $PubApiTest::test_config->{'test_formdata'} = 'hash';
-$PubApiTest::test_config->{'formdata'}      = { 'key' => 'value' };
+$PubApiTest::test_config->{'formdata'}      = { 'key' => 'value', 'api.version' => 1 };
 $PubApiTest::test_config->{'call'}          = 'whm_api-refform';
+$res = $pubapi->whm_api( 'loadavg', { 'key' => 'value' } );
+is( ref $res, 'HASH', 'Returned format ok for ' . $PubApiTest::test_config->{'call'} );
+
+$PubApiTest::test_config->{'test_formdata'} = 'hash';
+$PubApiTest::test_config->{'formdata'}      = { 'key' => 'value', 'api.version' => 0 };
+$PubApiTest::test_config->{'call'}          = 'whm_api-refapi0';
+$res = $pubapi->whm_api( 'loadavg', $PubApiTest::test_config->{'formdata'} );
+is( ref $res, 'HASH', 'Returned format ok for ' . $PubApiTest::test_config->{'call'} );
+
+$PubApiTest::test_config->{'test_formdata'} = 'hash';
+$PubApiTest::test_config->{'formdata'}      = { 'key' => 'value', 'api.version' => 1 };
+$PubApiTest::test_config->{'call'}          = 'whm_api-refapi1';
 $res = $pubapi->whm_api( 'loadavg', $PubApiTest::test_config->{'formdata'} );
 is( ref $res, 'HASH', 'Returned format ok for ' . $PubApiTest::test_config->{'call'} );
 
 $PubApiTest::test_config->{'test_formdata'} = 'string';
-$PubApiTest::test_config->{'formdata'}      = 'one&two';
+$PubApiTest::test_config->{'formdata'}      = 'api.version=1&one&two';
 $PubApiTest::test_config->{'call'}          = 'whm_api-stringform';
-$res = $pubapi->whm_api( 'loadavg', $PubApiTest::test_config->{'formdata'} );
+$res = $pubapi->whm_api( 'loadavg', 'one&two' );
+is( ref $res, 'HASH', 'Returned format ok for ' . $PubApiTest::test_config->{'call'} );
+
+$PubApiTest::test_config->{'test_formdata'} = 'string';
+$PubApiTest::test_config->{'formdata'}      = 'api.version=0&one&two';
+$PubApiTest::test_config->{'call'}          = 'whm_api-stringapi0';
+$res = $pubapi->whm_api( 'loadavg', 'api.version=0&one&two' );
 is( ref $res, 'HASH', 'Returned format ok for ' . $PubApiTest::test_config->{'call'} );
 
 delete $PubApiTest::test_config->{'formdata'};

--- a/t/lib/PubApiTest.pm
+++ b/t/lib/PubApiTest.pm
@@ -2,7 +2,7 @@ package PubApiTest;
 
 use cPanel::PublicAPI;
 
-@PubApiTest::ISA= qw( cPanel::PublicAPI );
+@PubApiTest::ISA = qw( cPanel::PublicAPI );
 
 use strict;
 use warnings;
@@ -20,39 +20,39 @@ sub api_request {
         if ( $test_config->{'badcall'} eq 'whmapi' ) {
             $badcall_return = '{"error":"Unknown App Requested: asdf"}';
         }
-        elsif ( $test_config->{'badcall'} eq 'cpanelapi2') {
+        elsif ( $test_config->{'badcall'} eq 'cpanelapi2' ) {
             $badcall_return = '{"cpanelresult":{"apiversion":2,"error":"Could not find function \'test\' in module \'Test\'","func":"test","module":"Test"}}';
         }
-        elsif ( $test_config->{'badcall'} eq 'cpanelapi1') {
+        elsif ( $test_config->{'badcall'} eq 'cpanelapi1' ) {
             $badcall_return = '{"apiversion":"1","type":"event","module":"Test","func":"test","source":"module","data":{"result":""},"event":{"reason":"Test::test() failed: Undefined subroutine &Cpanel::Test::Test_test called at (eval 21) line 1.\n","result":0}}';
         }
         return 0, 'failed', \$badcall_return;
     }
-    
+
     is( $service, $test_config->{'service'}, 'Service is correct for ' . $test_config->{'call'} );
-    is( $uri, $test_config->{'uri'}, 'URI is correct for ' . $test_config->{'call'} );
-    is( $method, $test_config->{'method'}, 'Method is correct for ' . $test_config->{'call'} );
+    is( $uri,     $test_config->{'uri'},     'URI is correct for ' . $test_config->{'call'} );
+    is( $method,  $test_config->{'method'},  'Method is correct for ' . $test_config->{'call'} );
     if ( exists $test_config->{'test_formdata'} && $test_config->{'test_formdata'} eq 'hash' ) {
         is_deeply( $formdata, $test_config->{'formdata'}, 'Formdata is correct for ' . $test_config->{'call'} );
     }
-    elsif ( exists $test_config->{'test_formdata'} && $test_config->{'test_formdata'} eq 'string') {
+    elsif ( exists $test_config->{'test_formdata'} && $test_config->{'test_formdata'} eq 'string' ) {
         is( $formdata, $test_config->{'formdata'}, 'Fromdata is correct for ' . $test_config->{'call'} );
     }
-    
+
     my $return_format = 'string';
     if ( $uri =~ /\/json-api\// ) {
         $return_format = 'json';
     }
-    elsif ( $uri =~ /\/xml-api\//) {
+    elsif ( $uri =~ /\/xml-api\// ) {
         $return_format = 'xml';
     }
-    is ( $return_format, $test_config->{'return_format'}, 'Serialization format correct for '  . $test_config->{'call'} );
+    is( $return_format, $test_config->{'return_format'}, 'Serialization format correct for ' . $test_config->{'call'} );
 
     my $return;
     if ( $return_format eq 'json' ) {
         $return = '{"something":"somethinglese"}';
     }
-    elsif( $return_format eq 'xml' ) {
+    elsif ( $return_format eq 'xml' ) {
         $return = '<node><something>somethingelse</something></node>';
     }
     else {

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -10,13 +10,13 @@ unless ( $ENV{RELEASE_TESTING} ) {
 my $min_tpc = 1.08;
 eval "use Test::Pod::Coverage $min_tpc";
 plan skip_all => "Test::Pod::Coverage $min_tpc required for testing POD coverage"
-    if $@;
+  if $@;
 
 # Test::Pod::Coverage doesn't require a minimum Pod::Coverage version,
 # but older versions don't recognize some common documentation styles
 my $min_pc = 0.18;
 eval "use Pod::Coverage $min_pc";
 plan skip_all => "Pod::Coverage $min_pc required for testing POD coverage"
-    if $@;
+  if $@;
 
 all_pod_coverage_ok();


### PR DESCRIPTION
Not all API calls are available in v0.  It's confusing to developers to try to make an API call, only to be told it doesn't exist.  Furthermore, some of the v0 calls have bizarre parameter names or odd behavior that has been fixed in v1.  Change the default for WHM API calls to v1.

Note that users can still pass api.version=0 if they want the old behavior.