### PR TITLE
Use HTTP::Tiny to implement HTTP support.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,6 +17,7 @@ WriteMakefile(
         'URI::Escape' => 3,
         'IO::Socket::INET' => 1.31,
         'IO::Socket::SSL' => 1.33,
+        'HTTP::Tiny' => 0.042,
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'cPanel-PublicAPI-*' },

--- a/lib/cPanel/PublicAPI.pm
+++ b/lib/cPanel/PublicAPI.pm
@@ -35,9 +35,9 @@ use strict;
 use Socket           ();
 use Carp             ();
 use MIME::Base64     ();
+use HTTP::Tiny       ();
 use IO::Socket::INET ();
 
-my ( $whm_sock, $whm_sock_host, $loaded_ssl );
 our %CFG;
 
 my %PORT_DB = (
@@ -70,18 +70,8 @@ sub new {
     else {
         $self->{'usessl'} = 1;
     }
-    if ( exists $OPTS{'ssl_verify_mode'} ) {
-        $self->{'ssl_verify_mode'} = $OPTS{'ssl_verify_mode'};
-    }
-    else {
-        $self->{'ssl_verify_mode'} = 1;
-    }
-    if ( exists $OPTS{'keepalive'} ) {
-        $self->{'keepalive'} = int $OPTS{'keepalive'};
-    }
-    else {
-        $self->{'keepalive'} = 0;
-    }
+    my $verify    = exists $OPTS{'ssl_verify_mode'} ? $OPTS{'ssl_verify_mode'} : 1;
+    my $keepalive = exists $OPTS{'keepalive'}       ? int $OPTS{'keepalive'}   : 0;
 
     if ( exists $OPTS{'ip'} ) {
         $self->{'ip'} = $OPTS{'ip'};
@@ -92,6 +82,13 @@ sub new {
     else {
         $self->{'ip'} = '127.0.0.1';
     }
+
+    $self->{'ua'} = HTTP::Tiny->new(
+        agent      => "cPanel::PublicAPI/$VERSION ",
+        verify_SSL => $verify,
+        keep_alive => $keepalive,
+        timeout    => $self->{'timeout'},
+    );
 
     if ( exists $OPTS{'error_log'} && $OPTS{'error_log'} ne 'STDERR' ) {
         if ( !open( $self->{'error_fh'}, '>>', $OPTS{'error_log'} ) ) {
@@ -232,7 +229,7 @@ sub api_request {
 
     $formdata ||= '';
     $method   ||= 'GET';
-    $headers  ||= '';
+    $headers  ||= {};
 
     $self->debug("api_request: ( $self, $service, $uri, $method, $formdata, $headers )") if $self->{'debug'};
 
@@ -259,19 +256,6 @@ sub api_request {
     my $port;
 
     if ( $self->{'usessl'} ) {
-        if ( !$loaded_ssl ) {
-            eval { require IO::Socket::SSL; };
-            if ($@) {
-                die "Failed to load IO::Socket::SSL: $@.";
-            }
-            Net::SSLeay::load_error_strings();
-            Net::SSLeay::OpenSSL_add_ssl_algorithms();
-            Net::SSLeay::ERR_load_crypto_strings();
-            Net::SSLeay::randomize();
-            IO::Socket::SSL->import('inet4');    # see case 16674
-            $loaded_ssl = 1;
-        }
-        IO::Socket::SSL->import('inet4');        # see case 16674
         $port = $service =~ /^\d+$/ ? $service : $PORT_DB{$service}{'ssl'};
     }
     else {
@@ -283,21 +267,19 @@ sub api_request {
     eval {
         if ( !$self->{'user'} ) {
             $self->error("You must specify a user to login as.");
-            die $self->{'error'};                #exit eval
+            die $self->{'error'};    #exit eval
         }
         my $remote_server = $self->{'ip'}   || $self->{'host'};
         my $server_name   = $self->{'host'} || $self->{'ip'};
         if ( !$remote_server ) {
             $self->error("You must set a host to connect to. (missing 'host' and 'ip' parameter)");
-            die $self->{'error'};                #exit eval
+            die $self->{'error'};    #exit eval
         }
         $server_name =~ s/\s*//g;
-        my $keepalive         = $self->{'keepalive'} ? 1 : 0;
         my $connection_string = $remote_server . ':' . $port;
         my $attempts          = 0;
         my $hassigpipe;
         my $finished_request = 0;
-        my $ssl_verify_mode  = $self->{'ssl_verify_mode'};
 
         local $SIG{'ALRM'} = sub {
             $self->error('Connection Timed Out');
@@ -305,129 +287,69 @@ sub api_request {
         };
         local $SIG{'PIPE'} = sub { $hassigpipe = 1; };
         $orig_alarm = alarm($timeout);
-        my @connection_args = ( PeerHost => $remote_server, PeerPort => $port, SSL_verify_mode => $ssl_verify_mode );
+
+        $formdata = $self->format_http_query($formdata) if ref $formdata;
+
+        my $scheme = $self->{'usessl'} ? "https" : "http";
+        my $url = "$scheme://$remote_server:$port$uri";
+        my $content;
+        if ( $method eq 'POST' || $method eq 'PUT' ) {
+            $content = $formdata;
+        }
+        else {
+            $url .= "?$formdata";
+        }
+        if ( !ref $headers ) {
+            my @lines = split /\r\n/, $headers;
+            $headers = {};
+            foreach my $line (@lines) {
+                last unless length $line;
+                my ( $key, $value ) = split /:\s*/, $line, 2;
+                next unless length $key;
+                $headers->{$key} ||= [];
+                push @{ $headers->{$key} }, $value;
+            }
+        }
+        my $options = {
+            headers => {
+                %$headers,
+                'Authorization' => $authstr,
+            }
+        };
+        $options->{'content'} = $content if defined $content;
+        my $ua = $self->{'ua'};
         while ( ++$attempts < 3 ) {
             $hassigpipe = 0;
-            if ( !ref $whm_sock || !$whm_sock_host || $whm_sock_host ne $connection_string ) {
-                close($whm_sock) if ref $whm_sock;
-                $whm_sock =
-                  $self->{'usessl'}
-                  ? IO::Socket::SSL->new(@connection_args)
-                  : IO::Socket::INET->new($connection_string);
-                if ( !$whm_sock ) {
-                    undef $whm_sock;
-                    $self->error("Could not connect to $connection_string: $!");
-                    die $self->{'error'};    #exit eval
-                }
-                else {
-                    $whm_sock_host = $connection_string;
-                }
-            }
-            my $connection_type = ( $keepalive ? 'Keep-Alive' : 'Close' );
-
-            $headers = $self->format_http_headers($headers) if ref $headers;
-            if ( $method eq 'POST' || $method eq 'PUT' ) {
-                $formdata = $self->format_http_query($formdata) if ref $formdata;
-                print {$whm_sock} "$method $uri HTTP/1.1\r\nHost: $server_name\r\nConnection: $connection_type\r\n" . 'Content-Length: ' . length($formdata) . "\r\n" . "User-Agent: " . 'cPanel::PublicAPI (perl) ' . $VERSION . "\r\n" . "Authorization: $authstr\r\n$headers\r\n" . $formdata;
-                $self->debug( ( "$method $uri HTTP/1.1\r\nHost: $server_name\r\nConnection: $connection_type\r\n" . 'Content-Length: ' . length($formdata) . "\r\n" . "User-Agent: " . 'cPanel::PublicAPI (perl) ' . $VERSION . "\r\n" . "Authorization: $authstr\r\n$headers\r\n" . $formdata ) ) if $self->{'debug'};
-            }
-            else {
-                print {$whm_sock} "$method "
-                  . ( $uri . '?' . ( ref $formdata ? join( '&', map { $CFG{'uri_encoder_func'}->($_) . '=' . $CFG{'uri_encoder_func'}->( $formdata->{$_} ) } keys %{$formdata} ) : $formdata ) )
-                  . " HTTP/1.1\r\nHost: $server_name\r\nConnection: $connection_type\r\n"
-                  . "User-Agent: "
-                  . 'cPanel::PublicAPI (perl) '
-                  . $VERSION . "\r\n"
-                  . "Authorization: $authstr\r\n$headers\r\n";
-
-                $self->debug( "$method " . ( $uri . '?' . ( ref $formdata ? join( '&', map { $CFG{'uri_encoder_func'}->($_) . '=' . $CFG{'uri_encoder_func'}->( $formdata->{$_} ) } keys %{$formdata} ) : $formdata ) ) . " HTTP/1.1\r\nHost: $server_name\r\nConnection: $connection_type\r\n" . "User-Agent: " . 'cPanel::PublicAPI (perl) ' . $VERSION . "\r\n" . "Authorization: $authstr\r\n$headers\r\n" )
-                  if $self->{'debug'};
-
+            my $response = $ua->request( $method, $url, $options );
+            $self->debug("$method $url HTTP/1.1") if $self->{'debug'};
+            if ( $response->{'status'} == 599 ) {
+                $self->error("Could not connect to $url: $response->{'content'}");
+                die $self->{'error'};    #exit eval
             }
 
-            if ($hassigpipe) { undef $whm_sock_host; next; }    # http spec says to reconnect
-
-            my $inheaders   = 1;
-            my $httpheader  = readline($whm_sock);
-            my $http_status = $httpheader;
-
-            $self->debug("HTTP STATUS[$http_status]") if $self->{'debug'};
-
-            if ( $hassigpipe || !$httpheader ) { undef $whm_sock_host; next; }    # http spec says to reconnect
-
+            if ($hassigpipe) { next; }    # http spec says to reconnect
             my %HEADERS;
-            {
-                local $/ = ( $httpheader =~ tr/\r// ) ? "\r\n\r\n" : "\n\n";
-                %HEADERS = map { ( lc $_->[0], substr( $_->[1], 0, 8190 ) ) }     # lc the header and truncate the value to 8190 bytes
-                  map { [ ( split( /:\s*/, $_, 2 ) )[ 0, 1 ] ] }                  # split header into name, value - and place into an arrayref for the next map to alter
-                  split( /\r?\n/, readline($whm_sock) );                          # split each header
-            }
             if ( $self->{'debug'} ) {
+                %HEADERS = %{ $response->{'headers'} };
                 foreach my $header ( keys %HEADERS ) {
                     $self->debug("HEADER[$header]=[$HEADERS{$header}]");
                 }
-            }
-            {
                 if ( exists $HEADERS{'transfer-encoding'} && $HEADERS{'transfer-encoding'} =~ /chunked/i ) {
-                    $self->debug("READ TYPE=chunked") if $self->{'debug'};
-                    local $/ = "\r\n";
-                    my ( $size_to_read, $read_size, $read_buffer, $bytes_read );
-                  CHUNKED_READ:
-                    while (1) {
-                        chomp( $read_size = readline($whm_sock) );
-                        $size_to_read = hex($read_size) + 2;
-
-                        #if ( $self->{'debug'} ) {
-                        #    $self->debug("CHUNKED read_size=$read_size")               ;
-                        #    $self->debug("REQUESTING_READ size_to_read=$size_to_read") ;
-                        #}
-                        while ($size_to_read) {
-                            if ( !defined($read_size) || !( $bytes_read = read( $whm_sock, $read_buffer, $size_to_read ) ) ) {
-
-                                #$self->debug("FINSIHED READING CHUNKED DATA [$bytes_read]") if $self->{'debug'};
-                                last CHUNKED_READ;
-                            }
-                            $size_to_read -= $bytes_read;
-
-                            #$self->debug("BYTES READ = [$bytes_read] (remaining in chunk $size_to_read)") if $self->{'debug'};
-                            $page .=
-                                $size_to_read == 0 ? substr( $read_buffer, 0, -2 )
-                              : $size_to_read == 1 ? substr( $read_buffer, 0, -1 )
-                              :                      $read_buffer;
-                        }
-                        last if hex($read_size) == 0;
-                    }
-                    $keepalive = 0 if exists $HEADERS{'connection'} && $HEADERS{'connection'} =~ /close/i;
+                    $self->debug("READ TYPE=chunked");
                 }
                 elsif ( defined $HEADERS{'content-length'} ) {
-                    $self->debug("READ TYPE=content-length") if $self->{'debug'};
-                    my $bytes_to_read = int $HEADERS{'content-length'};
-                    my $bytes_read = $bytes_to_read ? read( $whm_sock, $page, $bytes_to_read ) : 0;
-                    if ( ( $bytes_to_read -= $bytes_read ) > 0 ) {
-                        while ( $bytes_read = read( $whm_sock, $page, $bytes_to_read, length $page ) ) {
-                            last if !$bytes_read || !( $bytes_to_read -= $bytes_read );
-                        }
-                    }
-                    $self->debug("READ TYPE=content-length: Failed to read response from server.  The connection was dropped with $bytes_to_read bytes left: $!\n") if $self->{'debug'} && $bytes_to_read;
-                    $keepalive = 0 if exists $HEADERS{'connection'} && $HEADERS{'connection'} =~ /close/i;
+                    $self->debug("READ TYPE=content-length");
                 }
                 else {
-                    $self->debug("READ TYPE=close") if $self->{'debug'};
-                    $keepalive = 0;
-                    local $/;
-                    $page = readline($whm_sock);    # read until we close ths socket
+                    $self->debug("READ TYPE=close");
                 }
             }
 
-            if ( $http_status !~ m/^HTTP\/1\.(0|1) 2/ ) {
-                $keepalive = 0;
-                $self->error("Server Error from $remote_server: $http_status");
+            if ( !$response->{'success'} ) {
+                $self->error("Server Error from $remote_server: $response->{'status'} $response->{'reason'}");
             }
 
-            if ( !$keepalive ) {
-                close($whm_sock);
-                undef $whm_sock_host;
-            }
+            $page = $response->{'content'};
 
             $finished_request = 1;
             last;


### PR DESCRIPTION
Rather than using custom code, depend on HTTP::Tiny and use it for HTTP
support.  This allows for simpler, more robust code, including IPv6
support, and lets cPanel::PublicAPI inherit future improvements to
HTTP::Tiny compliance and performance.

This has been tested with string headers, hashref headers, string formrefs, hashref formrefs, and accesshashes.  It correctly handles the case where a self-signed certificate is used both with ssl_verify_mode on and off.