### PR TITLE
Establish sessions when possible. Add support for 2FA.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,6 +18,7 @@ WriteMakefile(
         'IO::Socket::INET' => 1.31,
         'IO::Socket::SSL' => 1.33,
         'HTTP::Tiny' => 0.042,
+        'HTTP::CookieJar' => 0,
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'cPanel-PublicAPI-*' },

--- a/lib/cPanel/PublicAPI.pm
+++ b/lib/cPanel/PublicAPI.pm
@@ -29,14 +29,13 @@ package cPanel::PublicAPI;
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-our $VERSION = 2.0;
+our $VERSION = 2.1;
 
 use strict;
-use Socket           ();
-use Carp             ();
-use MIME::Base64     ();
-use HTTP::Tiny       ();
-use IO::Socket::INET ();
+use Carp            ();
+use MIME::Base64    ();
+use HTTP::Tiny      ();
+use HTTP::CookieJar ();
 
 our %CFG;
 
@@ -63,15 +62,7 @@ sub new {
 
     $self->{'debug'}   = $OPTS{'debug'}   || 0;
     $self->{'timeout'} = $OPTS{'timeout'} || 300;
-
-    if ( exists $OPTS{'usessl'} ) {
-        $self->{'usessl'} = $OPTS{'usessl'};
-    }
-    else {
-        $self->{'usessl'} = 1;
-    }
-    my $verify    = exists $OPTS{'ssl_verify_mode'} ? $OPTS{'ssl_verify_mode'} : 1;
-    my $keepalive = exists $OPTS{'keepalive'}       ? int $OPTS{'keepalive'}   : 0;
+    $self->{'usessl'} = exists $OPTS{'usessl'} ? $OPTS{'usessl'} : 1;
 
     if ( exists $OPTS{'ip'} ) {
         $self->{'ip'} = $OPTS{'ip'};
@@ -85,8 +76,8 @@ sub new {
 
     $self->{'ua'} = HTTP::Tiny->new(
         agent      => "cPanel::PublicAPI/$VERSION ",
-        verify_SSL => $verify,
-        keep_alive => $keepalive,
+        verify_SSL => ( exists $OPTS{'ssl_verify_mode'} ? $OPTS{'ssl_verify_mode'} : 1 ),
+        keep_alive => ( exists $OPTS{'keepalive'} ? int $OPTS{'keepalive'} : 0 ),
         timeout    => $self->{'timeout'},
     );
 
@@ -129,7 +120,6 @@ sub new {
             $self->debug("Got user password from the REMOTE_PASSWORD environment variables.") if $self->{'debug'};
             $OPTS{'pass'} = $ENV{'REMOTE_PASSWORD'};
         }
-
         else {
             Carp::confess('pass or access hash is a required parameter');
         }
@@ -143,6 +133,8 @@ sub new {
         $self->{'accesshash'} = $OPTS{'accesshash'};
         $self->debug("Using accesshash param from object creation") if $self->{'debug'};
     }
+
+    $self->_update_operating_mode();
 
     return $self;
 }
@@ -161,12 +153,14 @@ sub pass {
     my $self = shift;
     $self->{'pass'} = shift;
     delete $self->{'accesshash'};
+    $self->_update_operating_mode();
 }
 
 sub accesshash {
     my $self = shift;
     $self->{'accesshash'} = shift;
     delete $self->{'pass'};
+    $self->_update_operating_mode();
 }
 
 sub whm_api {
@@ -198,34 +192,18 @@ sub whm_api {
     my $uri = "/$query_format-api/$call";
 
     my ( $status, $statusmsg, $data ) = $self->api_request( 'whostmgr', $uri, 'POST', $formdata );
-    if ( $self->{'error'} ) {
-        die $self->{'error'};
-    }
-    if ( defined $format && ( $format eq 'json' || $format eq 'xml' ) ) {
-        return $$data;
-    }
-    else {
-        my $parsed_data;
-        eval { $parsed_data = $CFG{'serializer_can_deref'} ? $CFG{'api_serializer_obj'}->($data) : $CFG{'api_serializer_obj'}->($$data); };
-        if ( !ref $parsed_data ) {
-            $self->error("There was an issue with parsing the following response from cPanel or WHM: [data=[$$data]]");
-            die $self->{'error'};
+    return $self->_parse_returndata(
+        {
+            'caller' => 'whm_api',
+            'data'   => $data,
+            'format' => $format,
+            'call'   => $call
         }
-        if (
-            ( exists $parsed_data->{'error'} && $parsed_data->{'error'} =~ /Unknown App Requested/ ) ||    # xml-api v0 version
-            ( exists $parsed_data->{'metadata'}->{'reason'} && $parsed_data->{'metadata'}->{'reason'} =~ /Unknown app requested/ )
-          ) {                                                                                              # xml-api v1 version
-            $self->error("cPanel::PublicAPI::whm_api was called with the invalid API call of: $call.");
-            return;
-        }
-        return $parsed_data;
-    }
+    );
 }
 
 sub api_request {
     my ( $self, $service, $uri, $method, $formdata, $headers ) = @_;
-
-    $self->{'error'} = 0;
 
     $formdata ||= '';
     $method   ||= 'GET';
@@ -235,63 +213,48 @@ sub api_request {
 
     $self->_init() if !exists $CFG{'init'};
 
-    $self->{'error'} = undef;
+    undef $self->{'error'};
     my $timeout = $self->{'timeout'} || 300;
-
-    my $authstr;
-    if ( exists $self->{'accesshash'} ) {
-        $self->{'accesshash'} =~ s/[\r\n]//g;
-        $authstr = 'WHM ' . $self->{'user'} . ':' . $self->{'accesshash'};
-    }
-    elsif ( exists $self->{'pass'} ) {
-        $authstr = 'Basic ' . MIME::Base64::encode_base64( $self->{'user'} . ':' . $self->{'pass'} );
-        $authstr =~ s/[\r\n]//g;
-    }
-    else {
-        die 'No user name or password set, cannot execute query.';
-    }
 
     my $orig_alarm = 0;
     my $page;
-    my $port;
 
-    if ( $self->{'usessl'} ) {
-        $port = $service =~ /^\d+$/ ? $service : $PORT_DB{$service}{'ssl'};
-    }
-    else {
-        $port = $service =~ /^\d+$/ ? $service : $PORT_DB{$service}{'plaintext'};
-    }
-
+    my $port = $self->_determine_port_for_service($service);
     $self->debug("Found port for service $service to be $port (usessl=$self->{'usessl'})") if $self->{'debug'};
 
     eval {
-        if ( !$self->{'user'} ) {
-            $self->error("You must specify a user to login as.");
-            die $self->{'error'};    #exit eval
+        $self->{'remote_server'} = $self->{'ip'} || $self->{'host'};
+        $self->_validate_connection_settings();
+        if ( $self->{'operating_mode'} eq 'session' ) {
+            $self->_establish_session($service) if !( $self->{'security_tokens'}->{$service} && $self->{'cookie_jars'}->{$service} );
+            $self->{'ua'}->cookie_jar( $self->{'cookie_jars'}->{$service} );
         }
-        my $remote_server = $self->{'ip'}   || $self->{'host'};
-        my $server_name   = $self->{'host'} || $self->{'ip'};
-        if ( !$remote_server ) {
-            $self->error("You must set a host to connect to. (missing 'host' and 'ip' parameter)");
-            die $self->{'error'};    #exit eval
-        }
-        $server_name =~ s/\s*//g;
-        my $connection_string = $remote_server . ':' . $port;
-        my $attempts          = 0;
-        my $hassigpipe;
+
+        my $remote_server    = $self->{'remote_server'};
+        my $attempts         = 0;
         my $finished_request = 0;
+        my $hassigpipe;
 
         local $SIG{'ALRM'} = sub {
             $self->error('Connection Timed Out');
             die $self->{'error'};
         };
+
         local $SIG{'PIPE'} = sub { $hassigpipe = 1; };
         $orig_alarm = alarm($timeout);
 
         $formdata = $self->format_http_query($formdata) if ref $formdata;
 
         my $scheme = $self->{'usessl'} ? "https" : "http";
-        my $url = "$scheme://$remote_server:$port$uri";
+        my $url = "$scheme://$remote_server:$port";
+        if ( $self->{'operating_mode'} eq 'session' ) {
+            my $security_token = $self->{'security_tokens'}->{$service};
+            $url .= '/' . $self->{'security_tokens'}->{$service} . $uri;
+        }
+        else {
+            $url .= $uri;
+        }
+
         my $content;
         if ( $method eq 'POST' || $method eq 'PUT' ) {
             $content = $formdata;
@@ -299,6 +262,8 @@ sub api_request {
         else {
             $url .= "?$formdata";
         }
+        $self->debug("URL: $url") if $self->{'debug'};
+
         if ( !ref $headers ) {
             my @lines = split /\r\n/, $headers;
             $headers = {};
@@ -310,18 +275,15 @@ sub api_request {
                 push @{ $headers->{$key} }, $value;
             }
         }
+
         my $options = {
-            headers => {
-                %$headers,
-                'Authorization' => $authstr,
-            }
+            headers => $headers,
         };
         $options->{'content'} = $content if defined $content;
         my $ua = $self->{'ua'};
         while ( ++$attempts < 3 ) {
             $hassigpipe = 0;
             my $response = $ua->request( $method, $url, $options );
-            $self->debug("$method $url HTTP/1.1") if $self->{'debug'};
             if ( $response->{'status'} == 599 ) {
                 $self->error("Could not connect to $url: $response->{'content'}");
                 die $self->{'error'};    #exit eval
@@ -369,6 +331,101 @@ sub api_request {
     return ( $self->{'error'} ? 0 : 1, $self->{'error'}, \$page );
 }
 
+sub establish_tfa_session {
+    my ( $self, $service, $tfa_token ) = @_;
+    if ( $self->{'operating_mode'} ne 'session' ) {
+        $self->error("2FA-authenticated sessions are not supported when using accesshash keys");
+        die $self->{'error'};
+    }
+    if ( !( $service && $tfa_token ) ) {
+        $self->error("You must specify the service name, and the 2FA token in order to establish a 2FA-authenticated session");
+        die $self->{'error'};
+    }
+
+    undef $self->{'cookie_jars'}->{$service};
+    undef $self->{'security_tokens'}->{$service};
+    return $self->_establish_session( $service, $tfa_token );
+}
+
+sub _validate_connection_settings {
+    my $self = shift;
+
+    if ( !$self->{'user'} ) {
+        $self->error("You must specify a user to login as.");
+        die $self->{'error'};
+    }
+
+    if ( !$self->{'remote_server'} ) {
+        $self->error("You must set a host to connect to. (missing 'host' and 'ip' parameter)");
+        die $self->{'error'};
+    }
+}
+
+sub _update_operating_mode {
+    my $self = shift;
+
+    if ( exists $self->{'accesshash'} ) {
+        $self->{'accesshash'} =~ s/[\r\n]//g;
+        $self->{'ua'}->default_headers( { 'Authorization' => 'WHM ' . $self->{'user'} . ':' . $self->{'accesshash'} } );
+        $self->{'operating_mode'} = 'accesshash';
+    }
+    elsif ( exists $self->{'pass'} ) {
+        $self->{'operating_mode'} = 'session';
+
+        # This is called whenever the pass or accesshash is changed,
+        # so we reset the cookie jars, and tokens on such changes
+        $self->{'cookie_jars'}     = { map { $_ => undef } keys %PORT_DB };
+        $self->{'security_tokens'} = { map { $_ => undef } keys %PORT_DB };
+    }
+    else {
+        $self->error('You must specify an accesshash or password');
+        die $self->{'error'};
+    }
+}
+
+sub _establish_session {
+    my ( $self, $service, $tfa_token ) = @_;
+
+    return if $self->{'operating_mode'} ne 'session';
+    return if $self->{'security_tokens'}->{$service} && $self->{'cookie_jars'}->{$service};
+
+    $self->{'cookie_jars'}->{$service} = HTTP::CookieJar->new();
+    $self->{'ua'}->cookie_jar( $self->{'cookie_jars'}->{$service} );
+
+    my $port   = $self->_determine_port_for_service($service);
+    my $scheme = $self->{'usessl'} ? "https" : "http";
+    my $url    = "$scheme://$self->{'remote_server'}:$port/login";
+    my $resp   = $self->{'ua'}->post_form(
+        $url,
+        {
+            'user' => $self->{'user'},
+            'pass' => $self->{'pass'},
+            ( $tfa_token ? ( 'tfa_token' => $tfa_token ) : () ),
+        },
+    );
+
+    if ( my $security_token = ( split /\//, $resp->{'headers'}->{'location'} )[1] ) {
+        $self->{'security_tokens'}->{$service} = $security_token;
+        return 1;
+    }
+
+    $self->error("Failed to establish session and parse security token: $resp->{'status'} $resp->{'reason'}");
+    die $self->{'error'};
+}
+
+sub _determine_port_for_service {
+    my ( $self, $service ) = @_;
+
+    my $port;
+    if ( $self->{'usessl'} ) {
+        $port = $service =~ /^\d+$/ ? $service : $PORT_DB{$service}{'ssl'};
+    }
+    else {
+        $port = $service =~ /^\d+$/ ? $service : $PORT_DB{$service}{'plaintext'};
+    }
+    return $port;
+}
+
 sub cpanel_api1_request {
     my ( $self, $service, $cfg, $formdata, $format ) = @_;
 
@@ -391,22 +448,14 @@ sub cpanel_api1_request {
     $formdata->{ 'cpanel_' . $query_format . 'api_apiversion' } = 1;
 
     my ( $status, $statusmsg, $data ) = $self->api_request( $service, '/' . $query_format . '-api/cpanel', ( ( scalar keys %$formdata < 10 && _total_form_length( $formdata, 1024 ) < 1024 ) ? 'GET' : 'POST' ), $formdata );
-    if ( defined $format && ( $format eq 'json' || $format eq 'xml' ) ) {
-        return $$data;
-    }
-    else {
-        my $parsed_data;
-        eval { $parsed_data = $CFG{'serializer_can_deref'} ? $CFG{'api_serializer_obj'}->($data) : $CFG{'api_serializer_obj'}->($$data); };
-        if ( !ref $parsed_data ) {
-            $self->error("There was an issue with parsing the following response from cPanel or WHM:\n$$data");
-            die $self->{'error'};
+
+    return $self->_parse_returndata(
+        {
+            'caller' => 'cpanel_api1',
+            'data'   => $data,
+            'format' => $format,
         }
-        if ( exists $parsed_data->{'event'}->{'reason'} && $parsed_data->{'event'}->{'reason'} =~ /failed: Undefined subroutine/ ) {
-            $self->error( "cPanel::PublicAPI::cpanel_api1_request was called with the invalid API1 call of: " . $parsed_data->{'module'} . '::' . $parsed_data->{'func'} );
-            return;
-        }
-        return $parsed_data;
-    }
+    );
 }
 
 sub cpanel_api2_request {
@@ -427,22 +476,81 @@ sub cpanel_api2_request {
     $formdata->{ 'cpanel_' . $query_format . 'api_apiversion' } = 2;
     my ( $status, $statusmsg, $data ) = $self->api_request( $service, '/' . $query_format . '-api/cpanel', ( ( scalar keys %$formdata < 10 && _total_form_length( $formdata, 1024 ) < 1024 ) ? 'GET' : 'POST' ), $formdata );
 
-    if ( defined $format && ( $format eq 'json' || $format eq 'xml' ) ) {
-        return $$data;
+    return $self->_parse_returndata(
+        {
+            'caller' => 'cpanel_api2',
+            'data'   => $data,
+            'format' => $format,
+        }
+    );
+}
+
+sub _parse_returndata {
+    my ( $self, $opts_hr ) = @_;
+
+    if ( $self->{'error'} ) {
+        die $self->{'error'};
+    }
+    elsif ( ${ $opts_hr->{'data'} } =~ m/tfa_login_form/ ) {
+        $self->error("Two-Factor Authentication enabled on the account. Establish a session with the security token, or disable 2FA on the account");
+        die $self->{'error'};
+    }
+
+    if ( defined $opts_hr->{'format'} && ( $opts_hr->{'format'} eq 'json' || $opts_hr->{'format'} eq 'xml' ) ) {
+        return ${ $opts_hr->{'data'} };
     }
     else {
         my $parsed_data;
-        eval { $parsed_data = $CFG{'serializer_can_deref'} ? $CFG{'api_serializer_obj'}->($data) : $CFG{'api_serializer_obj'}->($$data); };
+        eval { $parsed_data = $CFG{'serializer_can_deref'} ? $CFG{'api_serializer_obj'}->( $opts_hr->{'data'} ) : $CFG{'api_serializer_obj'}->( ${ $opts_hr->{'data'} } ); };
         if ( !ref $parsed_data ) {
-            $self->error("There was an issue with parsing the following response from cPanel or WHM:\n$$data");
+            $self->error("There was an issue with parsing the following response from cPanel or WHM: [data=[${$opts_hr->{'data'}}]]");
             die $self->{'error'};
         }
-        if ( exists $parsed_data->{'cpanelresult'}->{'error'} && $parsed_data->{'cpanelresult'}->{'error'} =~ /Could not find function/ ) {    # xml-api v1 version
-            $self->error( "cPanel::PublicAPI::cpanel_api2_request was called with the invalid API2 call of: " . $parsed_data->{'cpanelresult'}->{'module'} . '::' . $parsed_data->{'cpanelresult'}->{'func'} );
-            return;
-        }
-        return $parsed_data;
+
+        my $error_check_dt = {
+            'whm_api'     => \&_check_whm_api_errors,
+            'cpanel_api1' => \&_check_cpanel_api1_errors,
+            'cpanel_api2' => \&_check_cpanel_api2_errors,
+        };
+        return $error_check_dt->{ $opts_hr->{'caller'} }->( $self, $opts_hr->{'call'}, $parsed_data );
     }
+}
+
+sub _check_whm_api_errors {
+    my ( $self, $call, $parsed_data ) = @_;
+
+    if (
+        ( exists $parsed_data->{'error'} && $parsed_data->{'error'} =~ /Unknown App Requested/ ) ||    # xml-api v0 version
+        ( exists $parsed_data->{'metadata'}->{'reason'} && $parsed_data->{'metadata'}->{'reason'} =~ /Unknown app\s+(?:\(.+\))?\s+requested/ )    # xml-api v1 version
+      ) {
+        $self->error("cPanel::PublicAPI::whm_api was called with the invalid API call of: $call.");
+        return;
+    }
+    return $parsed_data;
+}
+
+sub _check_cpanel_api1_errors {
+    my ( $self, undef, $parsed_data ) = @_;
+    if (
+        exists $parsed_data->{'event'}->{'reason'} && (
+            $parsed_data->{'event'}->{'reason'} =~ /failed: Undefined subroutine/ ||                                                              # pre-11.44 error message
+            $parsed_data->{'event'}->{'reason'} =~ m/failed: Can\'t use string/                                                                   # 11.44+ error message
+        )
+      ) {
+        $self->error( "cPanel::PublicAPI::cpanel_api1_request was called with the invalid API1 call of: " . $parsed_data->{'module'} . '::' . $parsed_data->{'func'} );
+        return;
+    }
+    return $parsed_data;
+}
+
+sub _check_cpanel_api2_errors {
+    my ( $self, undef, $parsed_data ) = @_;
+
+    if ( exists $parsed_data->{'cpanelresult'}->{'error'} && $parsed_data->{'cpanelresult'}->{'error'} =~ /Could not find function/ ) {           # xml-api v1 version
+        $self->error( "cPanel::PublicAPI::cpanel_api2_request was called with the invalid API2 call of: " . $parsed_data->{'cpanelresult'}->{'module'} . '::' . $parsed_data->{'cpanelresult'}->{'func'} );
+        return;
+    }
+    return $parsed_data;
 }
 
 sub _total_form_length {
@@ -541,3 +649,4 @@ sub format_http_query {
     }
     return $formdata;
 }
+

--- a/lib/cPanel/PublicAPI.pod
+++ b/lib/cPanel/PublicAPI.pod
@@ -125,7 +125,7 @@ There are two sets of credentials that can be used to authenticate to WHM.
 First we have the basic user/password combinations:
 
   use cPanel::PublicAPI;
-  my $pubapi = cPanel::PublicAPI->new( 'user' => 'foo', 'password' => 'bar' );
+  my $pubapi = cPanel::PublicAPI->new( 'user' => 'foo', 'pass' => 'bar' );
 
 The other type of authentication is accesshash authentication.  To configure accesshashes visit “Setup remote access key”
 in WHM which will generate an accesshash for your server if one does not already exist. It will store the generated accesshash
@@ -155,6 +155,43 @@ This module will fall back on different modules if one fails to load. This allow
 
 If you installed this module via CPAN, this should never be an issue.  If you are wishing to use this
 module on a system where you do not have access to compiled modules, JSON::PP is the recommended serializer.
+
+=head1 Two-Factor Authentication (2FA)
+
+cPanel version 54 and above allows users to configure 2FA on their accounts - this security policy requires that the API queries
+are performed after authenticating and establishing a session. The workflow to accomodate 2FA will be as so:
+
+    use cPanel::PublicAPI;
+
+    use lib '/usr/local/cpanel';
+    use Cpanel::Security::Authn::TwoFactorAuth::Google (); # only available in 11.54+
+
+    my $pubapi = cPanel::PublicAPI->new( 'user' => 'foo', 'pass' => 'bar' );
+    my $google_auth = Cpanel::Security::Authn::TwoFactorAuth::Google->new(
+        {
+            'account_name' => 'foo',
+            'secret'       => $user_2fa_secret,
+            'issuer'       => ''
+        }
+    );
+    $pubapi->establish_tfa_session('whostmgr', $google_auth->generate_code());
+    $pubapi->whm_api('applist');
+
+Anytime you change services (e.g. from 'whostmgr' to 'cpanel'), you must establish the 2FA session for the new service.
+
+    eval {
+        $pubapi->cpanel_api2_request('cpanel', { 'user' => 'foo', 'module' => 'MysqlFE', 'func' => 'listdbs' }, {} );
+    };
+    print "failed cause 2fa session wasn't established\n" if $@;
+
+    $pubapi->establish_tfa_session('cpanel', $google_auth->generate_code());
+    eval {
+        $pubapi->cpanel_api2_request('cpanel', { 'user' => 'foo', 'module' => 'MysqlFE', 'func' => 'listdbs' }, {} );
+    };
+    print "success\n" if not $@;
+
+B<NOTE>: Additionally, since accesshash authentication is not allowed to establish sessions, you must use the 'user'/'pass'
+authentication in order to make API requests as a user with 2FA configured.
 
 =head1 Important Methods
 

--- a/t/02-construct.t
+++ b/t/02-construct.t
@@ -135,7 +135,7 @@ sub check_options {
     }
     elsif ( defined $OPTS{'accesshash'} ) {
         my $accesshash = $OPTS{'accesshash'};
-        $accesshash =~ s/[\r\n]//;
+        $accesshash =~ s/[\r\n]//g;
         is( $pubapi->{'accesshash'}, $accesshash, 'accesshash constructor option' );
     }
     else {

--- a/t/03-api-query.t
+++ b/t/03-api-query.t
@@ -67,11 +67,17 @@ if ( !-e '/var/cpanel/users/papiunit' ) {
             'ssl_verify_mode' => 0,
         );
         isa_ok( $cp_pubapi, 'cPanel::PublicAPI' );
+        is( $cp_pubapi->{'operating_mode'}, 'session', 'Session operating mode is set properly when user/pass is used' );
+        ok( !defined $cp_pubapi->{'cookie_jars'}->{'cpanel'},     'no cookies have been established for the cpanel service before the first query is made' );
+        ok( !defined $cp_pubapi->{'security_tokens'}->{'cpanel'}, 'no security_token has been set for the cpanel service before the first query is made' );
         $res = $cp_pubapi->api_request( 'cpanel', '/xml-api/cpanel', 'GET', 'cpanel_xmlapi_module=StatsBar&cpanel_xmlapi_func=stat&display=diskusage' );
         like( $$res, qr/<module>StatsBar<\/module>/, 'ssl cpanel get string params' );
 
+        my $security_token = $cp_pubapi->{'security_tokens'}->{'cpanel'};
+        ok( $security_token, 'security token for cpanel has been set upon first request' );
         $res = $cp_pubapi->api_request( 'cpanel', '/xml-api/cpanel', 'GET', { 'cpanel_xmlapi_module' => 'StatsBar', 'cpanel_xmlapi_func' => 'stat', 'display' => 'diskusage' } );
         like( $$res, qr/<module>StatsBar<\/module>/, 'ssl cpanel post hash params' );
+        is( $cp_pubapi->{'security_tokens'}->{'cpanel'}, $security_token, 'security_token was not changed when the second cpanel request was made' );
 
         $res = $cp_pubapi->api_request( 'cpanel', '/xml-api/cpanel', 'POST', 'cpanel_xmlapi_module=StatsBar&cpanel_xmlapi_func=stat&display=diskusage' );
         like( $$res, qr/<module>StatsBar<\/module>/, 'ssl cpanel get string params' );

--- a/t/04-tfa-sessions.t
+++ b/t/04-tfa-sessions.t
@@ -1,0 +1,135 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;    # last test to print
+
+use cPanel::PublicAPI ();
+
+my @getpwuid = getpwuid($>);
+my $homedir  = $getpwuid[7];
+my $user     = $getpwuid[0];
+
+if ( !-d '/usr/local/cpanel' ) {
+    plan skip_all => 'This test requires that cPanel and WHM are installed on a server';
+}
+
+if ( !-e $homedir . '/.accesshash' ) {
+    plan skip_all => 'This test requires that an account hash is defined (see "Setup Remote Access Keys" in WHM)';
+}
+
+check_cpanel_version() or plan skip_all => 'This test requires cPanel version 54 or higher';
+
+unshift @INC, '/usr/local/cpanel';
+require Cpanel::Security::Authn::TwoFactorAuth::Google;
+
+my $pubapi = check_api_access_and_config();
+
+if ( !-e '/var/cpanel/users/papiunit' ) {
+    my $password = generate_password();
+    my $res      = $pubapi->whm_api(
+        'createacct',
+        {
+            'username' => 'papiunit',
+            'password' => $password,
+            'domain'   => 'cpanel-public-api-test.acct',
+            'reseller' => 1,
+        }
+    );
+    like( $res->{'metadata'}->{'reason'}, qr/Account Creation Ok/, 'Test account created' );
+
+    $res = $pubapi->whm_api(
+        'setacls',
+        {
+            'reseller'        => 'papiunit',
+            'acl-create-acct' => 1,
+        }
+    );
+    ok( $res->{'metadata'}->{'result'}, 'Assigned create-acct ACL successfully' );
+
+    _test_tfa_as_reseller( 'papiunit', $password );
+
+    $res = $pubapi->whm_api(
+        'removeacct',
+        {
+            'user' => 'papiunit',
+        }
+    );
+    like( $res->{'metadata'}->{'reason'}, qr/papiunit account removed/, 'Test Account Removed' );
+}
+else {
+    plan skip_all => 'Unable to create test account. It already exists';
+}
+
+done_testing();
+
+sub _test_tfa_as_reseller {
+    my ( $reseller, $password ) = @_;
+
+    my $reseller_api = cPanel::PublicAPI->new( 'user' => $reseller, 'pass' => $password, 'ssl_verify_mode' => 0 );
+    my $res = $reseller_api->whm_api( 'twofactorauth_generate_tfa_config', {} );
+    ok( $res->{'metadata'}->{'result'}, 'Successfully called generate tfa config API call as reseller' );
+
+    my $tfa_secret = $res->{'data'}->{'secret'};
+    my $google_auth = Cpanel::Security::Authn::TwoFactorAuth::Google->new( { 'secret' => $tfa_secret, 'account_name' => '', 'issuer' => '' } );
+    $res = $reseller_api->whm_api(
+        'twofactorauth_set_tfa_config',
+        {
+            'secret'    => $tfa_secret,
+            'tfa_token' => $google_auth->generate_code(),
+        }
+    );
+    ok( $res->{'metadata'}->{'result'}, '2FA successfully configured for reseller' );
+
+    eval { $reseller_api->whm_api('loadavg') };
+    ok( $@, 'API calls fail without a 2FA session established' );
+
+    $reseller_api->establish_tfa_session( 'whostmgr', $google_auth->generate_code() );
+    $res = $reseller_api->whm_api('loadavg');
+    ok( defined $res->{'one'}, 'API call successfully made after establishing 2FA session' );
+}
+
+sub generate_password {
+    my @chars = ( 'A' .. 'Z', 'a' .. 'z', '0' .. '9' );
+    my $pass = '';
+    foreach ( 1 .. 32 ) {
+        $pass .= $chars[ int rand @chars ];
+    }
+    return $pass;
+}
+
+sub check_cpanel_version {
+    open( my $version_fh, '<', '/usr/local/cpanel/version' ) || return 0;
+    my $version = do { local $/; <$version_fh> };
+    chomp $version;
+    my ( $maj, $min, $rev, $sup ) = split /[\._]/, $version;
+    return 1 if $min >= 53;
+    return 0;
+}
+
+sub check_api_access_and_config {
+
+    open( my $config_fh, '<', '/var/cpanel/cpanel.config' ) || BAIL_OUT('Could not load /var/cpanel/cpanel.config');
+    foreach my $line ( readline($config_fh) ) {
+        next if $line !~ /=/;
+        chomp $line;
+        my ( $key, $value ) = split( /=/, $line, 2 );
+        if ( $key eq 'SecurityPolicy::TwoFactorAuth' ) {
+            plan skip_all => '2FA security policy is disabled on the server' if !$value;
+            last;
+        }
+    }
+
+    my $pubapi = cPanel::PublicAPI->new( 'ssl_verify_mode' => 0 );
+    my $res = eval { $pubapi->whm_api('applist') };
+    if ($@) {
+        plan skip_all => "Failed to verify API access as current user: $@";
+    }
+
+    if ( exists $res->{'data'}->{'app'} && ref $res->{'data'}->{'app'} eq 'ARRAY' ) {
+        return $pubapi if grep { $_ eq 'createacct' } @{ $res->{'data'}->{'app'} };
+    }
+
+    plan skip_all => "Current user doesn't appear to have proper privileges";
+}

--- a/t/lib/PubApiTest.pm
+++ b/t/lib/PubApiTest.pm
@@ -15,6 +15,7 @@ our $test_config = {};
 sub api_request {
     my ( $self, $service, $uri, $method, $formdata ) = @_;
 
+    undef $self->{'error'};
     if ( defined $test_config->{'badcall'} ) {
         my $badcall_return;
         if ( $test_config->{'badcall'} eq 'whmapi' ) {


### PR DESCRIPTION
    * If a 'user' and 'pass' are specified, then a session is
      established, and used for all subsequent API calls.
      However, if an 'accesshash' key is being used, then the
      behavior does not change - and basic HTTP auth is still
      used (i.e., the auth headers are sent with every request).
    * New workflow for working with Two-Factor Authentication
      (2FA) enabled accounts.
    * Some minor code cleanup.