### PR TITLE
Establish sessions when possible. Add support for 2FA.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,6 +18,7 @@ WriteMakefile(
         'IO::Socket::INET' => 1.31,
         'IO::Socket::SSL' => 1.33,
         'HTTP::Tiny' => 0.042,
+        'HTTP::CookieJar' => 0,
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'cPanel-PublicAPI-*' },

--- a/lib/cPanel/PublicAPI.pod
+++ b/lib/cPanel/PublicAPI.pod
@@ -125,7 +125,7 @@ There are two sets of credentials that can be used to authenticate to WHM.
 First we have the basic user/password combinations:
 
   use cPanel::PublicAPI;
-  my $pubapi = cPanel::PublicAPI->new( 'user' => 'foo', 'password' => 'bar' );
+  my $pubapi = cPanel::PublicAPI->new( 'user' => 'foo', 'pass' => 'bar' );
 
 The other type of authentication is accesshash authentication.  To configure accesshashes visit “Setup remote access key”
 in WHM which will generate an accesshash for your server if one does not already exist. It will store the generated accesshash
@@ -155,6 +155,43 @@ This module will fall back on different modules if one fails to load. This allow
 
 If you installed this module via CPAN, this should never be an issue.  If you are wishing to use this
 module on a system where you do not have access to compiled modules, JSON::PP is the recommended serializer.
+
+=head1 Two-Factor Authentication (2FA)
+
+cPanel version 54 and above allows users to configure 2FA on their accounts - this security policy requires that the API queries
+are performed after authenticating and establishing a session. The workflow to accomodate 2FA will be as so:
+
+    use cPanel::PublicAPI;
+
+    use lib '/usr/local/cpanel';
+    use Cpanel::Security::Authn::TwoFactorAuth::Google (); # only available in 11.54+
+
+    my $pubapi = cPanel::PublicAPI->new( 'user' => 'foo', 'pass' => 'bar' );
+    my $google_auth = Cpanel::Security::Authn::TwoFactorAuth::Google->new(
+        {
+            'account_name' => 'foo',
+            'secret'       => $user_2fa_secret,
+            'issuer'       => ''
+        }
+    );
+    $pubapi->establish_tfa_session('whostmgr', $google_auth->generate_code());
+    $pubapi->whm_api('applist');
+
+Anytime you change services (e.g. from 'whostmgr' to 'cpanel'), you must establish the 2FA session for the new service.
+
+    eval {
+        $pubapi->cpanel_api2_request('cpanel', { 'user' => 'foo', 'module' => 'MysqlFE', 'func' => 'listdbs' }, {} );
+    };
+    print "failed cause 2fa session wasn't established\n" if $@;
+
+    $pubapi->establish_tfa_session('cpanel', $google_auth->generate_code());
+    eval {
+        $pubapi->cpanel_api2_request('cpanel', { 'user' => 'foo', 'module' => 'MysqlFE', 'func' => 'listdbs' }, {} );
+    };
+    print "success\n" if not $@;
+
+B<NOTE>: Additionally, since accesshash authentication is not allowed to establish sessions, you must use the 'user'/'pass'
+authentication in order to make API requests as a user with 2FA configured.
 
 =head1 Important Methods
 

--- a/t/02-construct.t
+++ b/t/02-construct.t
@@ -19,14 +19,13 @@ if ( !-e $homedir . '/.accesshash' ) {
 
 check_options();
 check_options( 'debug' => 1, 'error_log' => '/dev/null' );
-check_options( 'timeout'         => 150 );
-check_options( 'usessl'          => 0 );
-check_options( 'ssl_verify_mode' => 0 );
-check_options( 'ip'              => '4.2.2.2' );
-check_options( 'host'            => 'zomg.cpanel.net' );
-check_options( 'error_log'       => '/dev/null' );
-check_options( 'user'            => 'bar' );
-check_options( 'pass'            => 'f00!3Df@' );
+check_options( 'timeout'   => 150 );
+check_options( 'usessl'    => 0 );
+check_options( 'ip'        => '4.2.2.2' );
+check_options( 'host'      => 'zomg.cpanel.net' );
+check_options( 'error_log' => '/dev/null' );
+check_options( 'user'      => 'bar' );
+check_options( 'pass'      => 'f00!3Df@' );
 my $accesshash = 'sdflkjl
 sdafjkl
 sdlfkjh';
@@ -99,13 +98,6 @@ sub check_options {
         is( $pubapi->{'usessl'}, 1, 'usessl default' );
     }
 
-    if ( defined $OPTS{'ssl_verify_mode'} ) {
-        is( $pubapi->{'ssl_verify_mode'}, $OPTS{'ssl_verify_mode'}, 'ssl_verify_mode constructor option' );
-    }
-    else {
-        is( $pubapi->{'ssl_verify_mode'}, 1, 'ssl_verify_mode default' );
-    }
-
     if ( defined $OPTS{'ip'} ) {
         is( $pubapi->{'ip'}, $OPTS{'ip'}, 'ip constructor option' );
     }
@@ -135,7 +127,7 @@ sub check_options {
     }
     elsif ( defined $OPTS{'accesshash'} ) {
         my $accesshash = $OPTS{'accesshash'};
-        $accesshash =~ s/[\r\n]//;
+        $accesshash =~ s/[\r\n]//g;
         is( $pubapi->{'accesshash'}, $accesshash, 'accesshash constructor option' );
     }
     else {
@@ -144,7 +136,7 @@ sub check_options {
             is( $pubapi->{'accesshash'}, $accesshash, 'accesshash default' );
         }
         else {
-            is( $pubapi->{'pass'}, $ENV{'REMOTE_PASS'}, 'password default' );
+            is( $pubapi->{'pass'}, $ENV{'REMOTE_PASSWORD'}, 'password default' );
         }
     }
 }

--- a/t/03-api-query.t
+++ b/t/03-api-query.t
@@ -67,11 +67,17 @@ if ( !-e '/var/cpanel/users/papiunit' ) {
             'ssl_verify_mode' => 0,
         );
         isa_ok( $cp_pubapi, 'cPanel::PublicAPI' );
+        is( $cp_pubapi->{'operating_mode'}, 'session', 'Session operating mode is set properly when user/pass is used' );
+        ok( !defined $cp_pubapi->{'cookie_jars'}->{'cpanel'},     'no cookies have been established for the cpanel service before the first query is made' );
+        ok( !defined $cp_pubapi->{'security_tokens'}->{'cpanel'}, 'no security_token has been set for the cpanel service before the first query is made' );
         $res = $cp_pubapi->api_request( 'cpanel', '/xml-api/cpanel', 'GET', 'cpanel_xmlapi_module=StatsBar&cpanel_xmlapi_func=stat&display=diskusage' );
         like( $$res, qr/<module>StatsBar<\/module>/, 'ssl cpanel get string params' );
 
+        my $security_token = $cp_pubapi->{'security_tokens'}->{'cpanel'};
+        ok( $security_token, 'security token for cpanel has been set upon first request' );
         $res = $cp_pubapi->api_request( 'cpanel', '/xml-api/cpanel', 'GET', { 'cpanel_xmlapi_module' => 'StatsBar', 'cpanel_xmlapi_func' => 'stat', 'display' => 'diskusage' } );
         like( $$res, qr/<module>StatsBar<\/module>/, 'ssl cpanel post hash params' );
+        is( $cp_pubapi->{'security_tokens'}->{'cpanel'}, $security_token, 'security_token was not changed when the second cpanel request was made' );
 
         $res = $cp_pubapi->api_request( 'cpanel', '/xml-api/cpanel', 'POST', 'cpanel_xmlapi_module=StatsBar&cpanel_xmlapi_func=stat&display=diskusage' );
         like( $$res, qr/<module>StatsBar<\/module>/, 'ssl cpanel get string params' );

--- a/t/04-tfa-sessions.t
+++ b/t/04-tfa-sessions.t
@@ -1,0 +1,135 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;    # last test to print
+
+use cPanel::PublicAPI ();
+
+my @getpwuid = getpwuid($>);
+my $homedir  = $getpwuid[7];
+my $user     = $getpwuid[0];
+
+if ( !-d '/usr/local/cpanel' ) {
+    plan skip_all => 'This test requires that cPanel and WHM are installed on a server';
+}
+
+if ( !-e $homedir . '/.accesshash' ) {
+    plan skip_all => 'This test requires that an account hash is defined (see "Setup Remote Access Keys" in WHM)';
+}
+
+check_cpanel_version() or plan skip_all => 'This test requires cPanel version 54 or higher';
+
+unshift @INC, '/usr/local/cpanel';
+require Cpanel::Security::Authn::TwoFactorAuth::Google;
+
+my $pubapi = check_api_access_and_config();
+
+if ( !-e '/var/cpanel/users/papiunit' ) {
+    my $password = generate_password();
+    my $res      = $pubapi->whm_api(
+        'createacct',
+        {
+            'username' => 'papiunit',
+            'password' => $password,
+            'domain'   => 'cpanel-public-api-test.acct',
+            'reseller' => 1,
+        }
+    );
+    like( $res->{'metadata'}->{'reason'}, qr/Account Creation Ok/, 'Test account created' );
+
+    $res = $pubapi->whm_api(
+        'setacls',
+        {
+            'reseller'        => 'papiunit',
+            'acl-create-acct' => 1,
+        }
+    );
+    ok( $res->{'metadata'}->{'result'}, 'Assigned create-acct ACL successfully' );
+
+    _test_tfa_as_reseller( 'papiunit', $password );
+
+    $res = $pubapi->whm_api(
+        'removeacct',
+        {
+            'user' => 'papiunit',
+        }
+    );
+    like( $res->{'metadata'}->{'reason'}, qr/papiunit account removed/, 'Test Account Removed' );
+}
+else {
+    plan skip_all => 'Unable to create test account. It already exists';
+}
+
+done_testing();
+
+sub _test_tfa_as_reseller {
+    my ( $reseller, $password ) = @_;
+
+    my $reseller_api = cPanel::PublicAPI->new( 'user' => $reseller, 'pass' => $password, 'ssl_verify_mode' => 0 );
+    my $res = $reseller_api->whm_api( 'twofactorauth_generate_tfa_config', {} );
+    ok( $res->{'metadata'}->{'result'}, 'Successfully called generate tfa config API call as reseller' );
+
+    my $tfa_secret = $res->{'data'}->{'secret'};
+    my $google_auth = Cpanel::Security::Authn::TwoFactorAuth::Google->new( { 'secret' => $tfa_secret, 'account_name' => '', 'issuer' => '' } );
+    $res = $reseller_api->whm_api(
+        'twofactorauth_set_tfa_config',
+        {
+            'secret'    => $tfa_secret,
+            'tfa_token' => $google_auth->generate_code(),
+        }
+    );
+    ok( $res->{'metadata'}->{'result'}, '2FA successfully configured for reseller' );
+
+    eval { $reseller_api->whm_api('loadavg') };
+    ok( $@, 'API calls fail without a 2FA session established' );
+
+    $reseller_api->establish_tfa_session( 'whostmgr', $google_auth->generate_code() );
+    $res = $reseller_api->whm_api('loadavg');
+    ok( defined $res->{'one'}, 'API call successfully made after establishing 2FA session' );
+}
+
+sub generate_password {
+    my @chars = ( 'A' .. 'Z', 'a' .. 'z', '0' .. '9' );
+    my $pass = '';
+    foreach ( 1 .. 32 ) {
+        $pass .= $chars[ int rand @chars ];
+    }
+    return $pass;
+}
+
+sub check_cpanel_version {
+    open( my $version_fh, '<', '/usr/local/cpanel/version' ) || return 0;
+    my $version = do { local $/; <$version_fh> };
+    chomp $version;
+    my ( $maj, $min, $rev, $sup ) = split /[\._]/, $version;
+    return 1 if $min >= 53;
+    return 0;
+}
+
+sub check_api_access_and_config {
+
+    open( my $config_fh, '<', '/var/cpanel/cpanel.config' ) || BAIL_OUT('Could not load /var/cpanel/cpanel.config');
+    foreach my $line ( readline($config_fh) ) {
+        next if $line !~ /=/;
+        chomp $line;
+        my ( $key, $value ) = split( /=/, $line, 2 );
+        if ( $key eq 'SecurityPolicy::TwoFactorAuth' ) {
+            plan skip_all => '2FA security policy is disabled on the server' if !$value;
+            last;
+        }
+    }
+
+    my $pubapi = cPanel::PublicAPI->new( 'ssl_verify_mode' => 0 );
+    my $res = eval { $pubapi->whm_api('applist') };
+    if ($@) {
+        plan skip_all => "Failed to verify API access as current user: $@";
+    }
+
+    if ( exists $res->{'data'}->{'app'} && ref $res->{'data'}->{'app'} eq 'ARRAY' ) {
+        return $pubapi if grep { $_ eq 'createacct' } @{ $res->{'data'}->{'app'} };
+    }
+
+    plan skip_all => "Current user doesn't appear to have proper privileges";
+}

--- a/t/lib/PubApiTest.pm
+++ b/t/lib/PubApiTest.pm
@@ -15,6 +15,7 @@ our $test_config = {};
 sub api_request {
     my ( $self, $service, $uri, $method, $formdata ) = @_;
 
+    undef $self->{'error'};
     if ( defined $test_config->{'badcall'} ) {
         my $badcall_return;
         if ( $test_config->{'badcall'} eq 'whmapi' ) {


### PR DESCRIPTION
    * If a 'user' and 'pass' are specified, then a session is
      established, and used for all subsequent API calls.
      However, if an 'accesshash' key is being used, then the
      behavior does not change - and basic HTTP auth is still
      used (i.e., the auth headers are sent with every request).
    * Added a new workflow for working with Two-Factor Authentication
      (2FA) enabled accounts.
    * Some minor code cleanup, and unit test fixes.