### PR TITLE
Improve unit tests. Bump IO::Socket::SSL version.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,7 @@ WriteMakefile(
         'JSON::XS'  => 2.0,
         'URI::Escape' => 3,
         'IO::Socket::INET' => 1.31,
-        'IO::Socket::SSL' => 1.33,
+        'IO::Socket::SSL' => 1.988, # Versions below this do not handle close calls properly
         'HTTP::Tiny' => 0.042,
         'HTTP::CookieJar' => 0,
     },

--- a/lib/cPanel/PublicAPI.pod
+++ b/lib/cPanel/PublicAPI.pod
@@ -31,7 +31,7 @@ cPanel::PublicAPI - A perl interface for interacting with cPanel
   # Perform an API2 query when authenticated as a user
   $cp->cpanel_api2_request('cpanel',
     {
-      'module' => Email,
+      'module' => 'Email',
       'func' => 'listpopswithdisk',
     }
   );
@@ -56,7 +56,7 @@ cPanel::PublicAPI - A perl interface for interacting with cPanel
         'func' => 'lastlogin',
         'user' => 'someuser'
     }
-  )
+  );
   # Pass parameters to an API1 query
   $cp->cpanel_api1_request('cpanel',
     {

--- a/t/04-tfa-sessions.t
+++ b/t/04-tfa-sessions.t
@@ -21,6 +21,9 @@ if ( !-e $homedir . '/.accesshash' ) {
 
 check_cpanel_version() or plan skip_all => 'This test requires cPanel version 54 or higher';
 
+eval { require MIME::Base32; require Digest::SHA; 1; } or do {
+    plan skip_all => 'This test requires the MIME::Base32 and Digest::SHA modules';
+};
 unshift @INC, '/usr/local/cpanel';
 require Cpanel::Security::Authn::TwoFactorAuth::Google;
 
@@ -111,14 +114,18 @@ sub check_cpanel_version {
 sub check_api_access_and_config {
 
     open( my $config_fh, '<', '/var/cpanel/cpanel.config' ) || BAIL_OUT('Could not load /var/cpanel/cpanel.config');
+    my $securitypolicy_enabled = 0;
     foreach my $line ( readline($config_fh) ) {
         next if $line !~ /=/;
         chomp $line;
         my ( $key, $value ) = split( /=/, $line, 2 );
         if ( $key eq 'SecurityPolicy::TwoFactorAuth' ) {
-            plan skip_all => '2FA security policy is disabled on the server' if !$value;
+            $securitypolicy_enabled = 1 if $value;
             last;
         }
+    }
+    if ( !$securitypolicy_enabled ) {
+        plan skip_all => '2FA security policy is disabled on the server';
     }
 
     my $pubapi = cPanel::PublicAPI->new( 'ssl_verify_mode' => 0 );


### PR DESCRIPTION
Made some improvements to the unit tests to ensure that they properly
pass/skip on non-cpanel systems, and systems without the modules
required by the test installed.

Bumped the version of IO::Socket::SSL required to 1.988 to ensure that
the socket close calls are properly handled (versions below 1.988
randomly fail on the close socket calls with a "connection reset by
peer" error)