### PR TITLE
Pod cleanups

### DIFF
--- a/lib/cPanel/PublicAPI.pod
+++ b/lib/cPanel/PublicAPI.pod
@@ -302,7 +302,7 @@ The function used for querying URLs directly is api_request().  It will always r
 
 =item * $formdata - The data you wish to pass to the URL
 
-=item * $headers - Any additional headers are to be passed with the request.  These can be either a flat string or as a hashref like {'headertitle' => 'headerdata'}
+=item * $headers - Any additional headers are to be passed with the request.  These can be either a flat string or as a hashref like {'headertitle' =E<gt> 'headerdata'}
 
 =back
 
@@ -370,7 +370,7 @@ would return:
 
 =over
 
-=item C<$pubapi-\>{'error'}>
+=item C<$pubapi-E<gt>{'error'}>
 
 =back
 

--- a/lib/cPanel/PublicAPI.pod
+++ b/lib/cPanel/PublicAPI.pod
@@ -1,3 +1,5 @@
+=encoding UTF-8
+
 =head1 NAME
 
 cPanel::PublicAPI - A perl interface for interacting with cPanel

--- a/lib/cPanel/PublicAPI/Utils.pod
+++ b/lib/cPanel/PublicAPI/Utils.pod
@@ -1,3 +1,5 @@
+=encoding UTF-8
+
 =head1 NAME
 
 cPanel::PublicAPI::Utils - Provides some internally used utility functions for cPanel::PublicAPI, should never be used externally.

--- a/lib/cPanel/PublicAPI/WHM.pod
+++ b/lib/cPanel/PublicAPI/WHM.pod
@@ -1,3 +1,5 @@
+=encoding UTF-8
+
 =head1 NAME
 
 cPanel::PublicAPI::WHM - Legacy interface for querying WHM.

--- a/lib/cPanel/PublicAPI/WHM/API.pod
+++ b/lib/cPanel/PublicAPI/WHM/API.pod
@@ -1,3 +1,5 @@
+=encoding UTF-8
+
 =head1 NAME
 
 cPanel::PublicAPI::WHM::API - Legacy interface for querying the xml-api.

--- a/lib/cPanel/PublicAPI/WHM/CachedVersion.pod
+++ b/lib/cPanel/PublicAPI/WHM/CachedVersion.pod
@@ -1,3 +1,5 @@
+=encoding UTF-8
+
 =head1 NAME
 
 cPanel::PublicAPI::WHM::CachedVersion - Allows for lookups of remote versions of cPanel & WHM.

--- a/lib/cPanel/PublicAPI/WHM/DNS.pod
+++ b/lib/cPanel/PublicAPI/WHM/DNS.pod
@@ -1,3 +1,5 @@
+=encoding UTF-8
+
 =head1 NAME
 
 cPanel::PublicAPI::WHM::DNS - A module for interacting with WHM's DNS clustering system.

--- a/lib/cPanel/PublicAPI/WHM/JSONAPI.pod
+++ b/lib/cPanel/PublicAPI/WHM/JSONAPI.pod
@@ -1,3 +1,5 @@
+=encoding UTF-8
+
 =head1 NAME
 
 cPanel::PublicAPI::WHM::API - Legacy interface for querying the xml-api.

--- a/lib/cPanel/PublicAPI/WHM/Legacy.pod
+++ b/lib/cPanel/PublicAPI/WHM/Legacy.pod
@@ -6,7 +6,7 @@ cPanel::PublicAPI::WHM::Legacy - A module for handling Cpanel::Accounting backwa
 
 =head1 DESCRIPTION
 
-This module should never be used, please use cPanel::PublicAPI->whm_api() instead.
+This module should never be used, please use cPanel::PublicAPI-E<gt>whm_api() instead.
 
 =head1 Bugs
 

--- a/lib/cPanel/PublicAPI/WHM/Legacy.pod
+++ b/lib/cPanel/PublicAPI/WHM/Legacy.pod
@@ -1,3 +1,5 @@
+=encoding UTF-8
+
 =head1 NAME
 
 cPanel::PublicAPI::WHM::Legacy - A module for handling Cpanel::Accounting backward compatibility within the cPanel::PublicAPI framework.

--- a/lib/cPanel/PublicAPI/WHM/XMLAPI.pod
+++ b/lib/cPanel/PublicAPI/WHM/XMLAPI.pod
@@ -1,3 +1,5 @@
+=encoding UTF-8
+
 =head1 NAME
 
 cPanel::PublicAPI::WHM::API - Legacy interface for querying the xml-api.


### PR DESCRIPTION
Clean up some issues with the Pod, including missing encoding declarations that caused perldoc to puke errors into the page.