### PR TITLE
Add support for API tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.tdy
+*.bak
+cPanel-PublicAPI-*
+/Makefile
+/blib
+/pm_to_blib
+/MYMETA.json
+/MYMETA.yml
+/Makefile.old

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,23 +3,24 @@ use warnings;
 use ExtUtils::MakeMaker;
 
 WriteMakefile(
-    NAME                => 'cPanel::PublicAPI',
-    AUTHOR              => q{cPanel, Inc. <integration@cpanel.net>},
-    VERSION_FROM        => 'lib/cPanel/PublicAPI.pm',
-    ABSTRACT_FROM       => 'lib/cPanel/PublicAPI.pod',
-    ($ExtUtils::MakeMaker::VERSION >= 6.3002
-      ? ('LICENSE'=> 'Modified BSD')
-      : ()),
-    PL_FILES            => {},
+    NAME          => 'cPanel::PublicAPI',
+    AUTHOR        => q{cPanel, Inc. <integration@cpanel.net>},
+    VERSION_FROM  => 'lib/cPanel/PublicAPI.pm',
+    ABSTRACT_FROM => 'lib/cPanel/PublicAPI.pod',
+    ( $ExtUtils::MakeMaker::VERSION >= 6.3002
+        ? ( 'LICENSE' => 'Modified BSD' )
+        : () ),
+    PL_FILES  => {},
     PREREQ_PM => {
-        'Test::More' => 0,
-        'JSON::XS'  => 2.0,
-        'URI::Escape' => 3,
+        'Test::More'       => 0,
+        'Test::Exception'  => 0,
+        'JSON::XS'         => 2.0,
+        'URI::Escape'      => 3,
         'IO::Socket::INET' => 1.31,
-        'IO::Socket::SSL' => 1.988, # Versions below this do not handle close calls properly
-        'HTTP::Tiny' => 0.042,
-        'HTTP::CookieJar' => 0,
+        'IO::Socket::SSL'  => 1.988,    # Versions below this do not handle close calls properly
+        'HTTP::Tiny'       => 0.042,
+        'HTTP::CookieJar'  => 0,
     },
-    dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
-    clean               => { FILES => 'cPanel-PublicAPI-*' },
+    dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
+    clean => { FILES    => 'cPanel-PublicAPI-*' },
 );

--- a/lib/cPanel/PublicAPI.pod
+++ b/lib/cPanel/PublicAPI.pod
@@ -13,7 +13,9 @@ cPanel::PublicAPI - A perl interface for interacting with cPanel
   # or specify a user/password
   my $cp = cPanel::PublicAPI->new( 'user' => 'someuser', 'pass' => 'somepass' );
   # or specify an accesshash
-  my $cp = cPanel::PublicAPI->new('user' => 'someuser', 'accesshash' => $accesshash );
+  my $cp = cPanel::PublicAPI->new( 'user' => 'someuser', 'accesshash' => $accesshash );
+  # or specify an API token
+  my $cp = cPanel::PublicAPI->new( 'user' => 'someuser', 'api_token' => $api_token );
   
   # Perform an xml-api query
   $cp->whm_api('listaccts');
@@ -90,7 +92,7 @@ a cPanel::PublicAPI object is constructed with the new() method.
 
   my $publicapi = cPanel::PublicAPI->new();
 
-When passed no parameters this create the object using the accesshash in ~/.accesshash.  If no .accesshash file exists, it will attempt to use the REMOTE_PASS environment variable, if that is not defined, object creation will error out.
+When passed no parameters, this will create the object using the accesshash in ~/.accesshash. If no .accesshash file exists, it will attempt to use the REMOTE_PASS environment variable. If the REMOTE_PASS variable is not defined, object creation will error out.
 
 =head3 new() parameters
 
@@ -103,6 +105,8 @@ options for new() are specified as a hash reference, the following parameters ar
 =item * pass - The password to use for authentication.
 
 =item * accesshash - The accesshash to use for authentication.
+
+=item * api_token - The API token to use for authentication.
 
 =item * timeout - The length of time (in seconds) before an http request should time out.  Default to 300.
 
@@ -122,22 +126,36 @@ options for new() are specified as a hash reference, the following parameters ar
 
 =head3 Notes about authentication
 
-There are two sets of credentials that can be used to authenticate to WHM.
+There are three sets of credentials that can be used to authenticate to WHM.
 
 First we have the basic user/password combinations:
 
   use cPanel::PublicAPI;
   my $pubapi = cPanel::PublicAPI->new( 'user' => 'foo', 'pass' => 'bar' );
 
-The other type of authentication is accesshash authentication.  To configure accesshashes visit “Setup remote access key”
+Next is API token authentication. To create an API token, visit "Manage API Tokens" in WHM and click Generate Token. Fill out
+the form and click Generate. Your token will appear in a special notice. Make certain that you save your API token in a safe location
+on your workstation. You cannot access the token after you navigate away from the interface or refresh the API Tokens table.
+
+To use an API token with this module, do the following:
+
+  use cPanel::PublicAPI;
+  my $pubapi = cPanel::PublicAPI->new( 'user' => 'foo', 'api_token' => $string_containing_api_token );
+
+
+Last is accesshash authentication.  To configure accesshashes, visit “Setup remote access key”
 in WHM which will generate an accesshash for your server if one does not already exist. It will store the generated accesshash
-in /root/.accesshash.  To use an accesshash with this module you can do something like the following:
+in ~/.accesshash.
+
+To use an accesshash with this module, do the following:
 
   use cPanel::PublicAPI;
   my $pubapi = cPanel::PublicAPI->new( 'user' => 'foo', 'accesshash' => $string_containing_access_hash );
 
-It should be noted that the access hash can contain newlines in it,  Newlines will be stripped by the object when
+It should be noted that the accesshash can contain newlines in it. Newlines will be stripped by the object when
 it attempts to perform a query.
+
+B<NOTE:> Accesshash authentication is deprecated in cPanel & WHM version 64.
 
 =head3 Dependencies
 
@@ -339,6 +357,14 @@ Allows you to change the password that your PublicAPI object is authenticating w
 =back
 
 Allows you to change the accesshash that your PublicAPI object is authenticating with, this will remove the stored password from the object.
+
+=over
+
+=item C<api_token()>
+
+=back
+
+Allows you to change the API token that your PublicAPI object is authenticating with, this will remove the stored password from the object.
 
 =over
 

--- a/lib/cPanel/PublicAPI/WHM/DNS.pod
+++ b/lib/cPanel/PublicAPI/WHM/DNS.pod
@@ -36,7 +36,7 @@ Call specific parameters:
 
 =item * $user - The user to authenticate DNS requests as.
 
-=item * $pass - The accesshash to authenticate DNS requests with
+=item * $pass - The accesshash or API token to authenticate DNS requests with
 
 =item * $version - The version of cPanel/WHM of the machine being added to the cluster
 

--- a/t/02-construct.t
+++ b/t/02-construct.t
@@ -1,9 +1,39 @@
 #!/usr/bin/perl
 
+# Copyright 2017, cPanel, Inc.
+# All rights reserved.
+# http://cpanel.net
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the owner nor the names of its contributors may be
+# used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 use strict;
 use warnings;
 
 use Test::More;
+use Test::Exception;
 
 use cPanel::PublicAPI ();
 
@@ -30,6 +60,11 @@ my $accesshash = 'sdflkjl
 sdafjkl
 sdlfkjh';
 check_options( 'accesshash' => $accesshash );
+check_options( 'api_token'  => 'sdfkjl' );
+throws_ok {
+    check_options( 'api_token' => 'sdfkjl', 'accesshash' => $accesshash );
+}
+qr/You cannot specify both an accesshash and an API token/, 'Dies when specifying both an accesshash and API token';
 
 my $pubapi = cPanel::PublicAPI->new( 'error_log' => '/dev/null' );
 
@@ -63,10 +98,14 @@ $pubapi->accesshash('onetwothreefour');
 is( $pubapi->{'accesshash'}, 'onetwothreefour', 'accesshash accessor' );
 ok( !exists $pubapi->{'pass'}, 'accesshash accessor deletes pass scalar' );
 
+$pubapi->api_token('fivesixseveneight');
+is( $pubapi->{'accesshash'}, 'fivesixseveneight', 'api_token accessor' );
+ok( !exists $pubapi->{'pass'}, 'api_token accessor deletes pass scalar' );
+
 my $header_string = $pubapi->format_http_headers( { 'Authorization' => 'Basic cm9vdDpsMGx1cnNtNHJ0IQ==' } );
 is( $header_string, "Authorization: Basic cm9vdDpsMGx1cnNtNHJ0IQ==\r\n", 'format_http_headers is ok' );
 
-can_ok( $pubapi, 'new', 'set_debug', 'user', 'pass', 'accesshash', 'whm_api', 'api_request', 'cpanel_api1_request', 'cpanel_api2_request', '_total_form_length', '_init_serializer', '_init', 'error', 'debug', 'format_http_query' );
+can_ok( $pubapi, 'new', 'set_debug', 'user', 'pass', 'accesshash', 'api_token', 'whm_api', 'api_request', 'cpanel_api1_request', 'cpanel_api2_request', '_total_form_length', '_init_serializer', '_init', 'error', 'debug', 'format_http_query' );
 
 done_testing();
 
@@ -124,6 +163,9 @@ sub check_options {
 
     if ( defined $OPTS{'pass'} ) {
         is( $pubapi->{'pass'}, $OPTS{'pass'}, 'pass constructor option' );
+    }
+    elsif ( defined $OPTS{'api_token'} ) {
+        is( $pubapi->{'accesshash'}, $OPTS{'api_token'}, 'api_token constructor option' );
     }
     elsif ( defined $OPTS{'accesshash'} ) {
         my $accesshash = $OPTS{'accesshash'};


### PR DESCRIPTION
Case PIG-2786: Added an 'api_token' option to the constructor so that a user
will have an explicit place to use their API token. Updated the constructor
unit test to test the new option.

Created a new unit test to test authentication using an API token.

Updated the POD documentation for authentication.

Additionally, updated the TFA unit test since it was failing.